### PR TITLE
Add schema class lookup with converter

### DIFF
--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -1,12 +1,25 @@
 use std::collections::HashMap;
 
-use linkml_meta::SchemaDefinition;
+use crate::identifier::{converter_from_schema, Identifier, IdentifierError};
+use curies::Converter;
+use linkml_meta::{ClassDefinition, SchemaDefinition};
 
 use crate::curie::curie2uri;
 
 pub struct SchemaView {
     schema_definitions: HashMap<String, SchemaDefinition>,
     primary_schema: Option<String>,
+    class_uri_index: HashMap<String, (String, String)>,
+}
+
+pub struct ClassView<'a> {
+    pub class: &'a ClassDefinition,
+}
+
+impl<'a> ClassView<'a> {
+    pub fn new(class: &'a ClassDefinition) -> Self {
+        Self { class }
+    }
 }
 
 impl SchemaView {
@@ -14,14 +27,52 @@ impl SchemaView {
         SchemaView {
             schema_definitions: HashMap::new(),
             primary_schema: None,
+            class_uri_index: HashMap::new(),
         }
     }
 
     pub fn add_schema(&mut self, schema: SchemaDefinition) -> Result<(), String> {
         let schema_uri = schema.id.clone();
+        let conv = converter_from_schema(&schema);
+        self.index_schema_classes(&schema_uri, &schema, &conv)
+            .map_err(|e| format!("{:?}", e))?;
         self.schema_definitions.insert(schema_uri.to_string(), schema);
         if self.primary_schema.is_none() {
             self.primary_schema = Some(schema_uri.to_string());
+        }
+        Ok(())
+    }
+
+    fn index_schema_classes(
+        &mut self,
+        schema_uri: &str,
+        schema: &SchemaDefinition,
+        conv: &Converter,
+    ) -> Result<(), IdentifierError> {
+        let default_prefix = schema.default_prefix.as_deref().unwrap_or(&schema.name);
+        for (class_name, class_def) in &schema.classes {
+            let default_uri = Identifier::new(&format!("{}:{}", default_prefix, class_name))
+                .to_uri(conv)
+                .map(|u| u.0)
+                .unwrap_or_else(|_| {
+                    format!("{}/{}", schema.id.trim_end_matches('/'), class_name)
+                });
+
+            if let Some(curi) = &class_def.class_uri {
+                let explicit_uri = Identifier::new(curi).to_uri(conv)?.0;
+                self.class_uri_index
+                    .entry(explicit_uri.clone())
+                    .or_insert_with(|| (schema_uri.to_string(), class_name.clone()));
+                if explicit_uri != default_uri {
+                    self.class_uri_index
+                        .entry(default_uri.clone())
+                        .or_insert_with(|| (schema_uri.to_string(), class_name.clone()));
+                }
+            } else {
+                self.class_uri_index
+                    .entry(default_uri)
+                    .or_insert_with(|| (schema_uri.to_string(), class_name.clone()));
+            }
         }
         Ok(())
     }
@@ -37,13 +88,43 @@ impl SchemaView {
                         if !self.schema_definitions.contains_key(&uri) {
                             unresolved.push(uri);
                         }
-                    },
-                    None => {
                     }
+                    None => {}
                 }
             }
         }
         unresolved
     }
 
+    pub fn get_class<'a>(
+        &'a self,
+        id: &Identifier,
+        conv: &Converter,
+    ) -> Result<Option<ClassView<'a>>, IdentifierError> {
+        let index = &self.class_uri_index;
+        match id {
+            Identifier::Name(name) => {
+                let primary = match &self.primary_schema {
+                    Some(p) => p,
+                    None => return Ok(None),
+                };
+                let schema = match self.schema_definitions.get(primary) {
+                    Some(s) => s,
+                    None => return Ok(None),
+                };
+                Ok(schema.classes.get(name).map(|c| ClassView::new(c)))
+            }
+            Identifier::Curie(_) | Identifier::Uri(_) => {
+                let target_uri = id.to_uri(conv)?;
+                if let Some((schema_uri, class_name)) = index.get(&target_uri.0) {
+                    if let Some(schema) = self.schema_definitions.get(schema_uri) {
+                        if let Some(class) = schema.classes.get(class_name) {
+                            return Ok(Some(ClassView::new(class)));
+                        }
+                    }
+                }
+                Ok(None)
+            }
+        }
+    }
 }

--- a/src/schemaview/tests/class_lookup.rs
+++ b/src/schemaview/tests/class_lookup.rs
@@ -1,0 +1,46 @@
+use schemaview::identifier::{converter_from_schemas, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn lookup_classes() {
+    let person_schema = from_yaml(Path::new(&data_path("person.yaml"))).unwrap();
+    let container_schema = from_yaml(Path::new(&data_path("container.yaml"))).unwrap();
+
+    let mut sv = SchemaView::new();
+    sv.add_schema(container_schema.clone()).unwrap();
+    sv.add_schema(person_schema.clone()).unwrap();
+
+    let conv = converter_from_schemas([&person_schema, &container_schema]);
+    assert!(conv.expand("personinfo:Person").is_ok());
+
+    // Container should be found by name in primary schema
+    let c = sv.get_class(&Identifier::new("Container"), &conv).unwrap();
+    assert!(c.is_some());
+
+    // Person only accessible by curie or uri
+    let p1 = sv
+        .get_class(&Identifier::new("personinfo:Person"), &conv)
+        .unwrap();
+    assert!(p1.is_some());
+    let p2 = sv.get_class(&Identifier::new("alt:Person"), &conv).unwrap();
+    assert!(p2.is_some());
+    let p_linkml = sv.get_class(&Identifier::new("linkml:Person"), &conv).unwrap();
+    assert!(p_linkml.is_some());
+    let p3 = sv
+        .get_class(
+            &Identifier::new("https://w3id.org/linkml/examples/personinfo/Person"),
+            &conv,
+        )
+        .unwrap();
+    assert!(p3.is_some());
+}

--- a/src/schemaview/tests/data/container.yaml
+++ b/src/schemaview/tests/data/container.yaml
@@ -1,0 +1,19 @@
+id: https://w3id.org/linkml/examples/container
+name: container
+prefixes:
+  container: https://w3id.org/linkml/examples/container/
+  personinfo: https://w3id.org/linkml/examples/personinfo/
+  alt: https://w3id.org/linkml/examples/personinfo/
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+  - https://w3id.org/linkml/examples/personinfo
+default_prefix: container
+classes:
+  Container:
+    tree_root: true
+    attributes:
+      persons:
+        multivalued: true
+        inlined_as_list: true
+        range: personinfo:Person

--- a/src/schemaview/tests/data/person.yaml
+++ b/src/schemaview/tests/data/person.yaml
@@ -1,0 +1,18 @@
+id: https://w3id.org/linkml/examples/personinfo
+name: personinfo
+prefixes:
+  personinfo: https://w3id.org/linkml/examples/personinfo/
+  alt: https://w3id.org/linkml/examples/personinfo/
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_prefix: personinfo
+classes:
+  Person:
+    class_uri: linkml:Person
+    attributes:
+      id:
+      full_name:
+      aliases:
+      phone:
+      age:


### PR DESCRIPTION
## Summary
- create converter helpers from SchemaDefinitions
- add ClassView wrapper and SchemaView::get_class
- test SchemaView using two sample LinkML schemas
- optimize class lookup by indexing URIs
- eager indexing and synonym handling for `class_uri`

## Testing
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6855083983b483298a810ba3f0db02f6