### PR TITLE
Implement slot caching within ClassView

### DIFF
--- a/src/schemaview/tests/data/person.yaml
+++ b/src/schemaview/tests/data/person.yaml
@@ -8,10 +8,13 @@ imports:
   - linkml:types
 default_prefix: personinfo
 classes:
-  Person:
-    class_uri: linkml:Person
+  NamedThing:
     attributes:
       id:
+  Person:
+    is_a: NamedThing
+    class_uri: linkml:Person
+    attributes:
       full_name:
       aliases:
       phone:

--- a/src/schemaview/tests/slot_view.rs
+++ b/src/schemaview/tests/slot_view.rs
@@ -1,0 +1,41 @@
+use schemaview::identifier::{converter_from_schemas, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::SchemaView;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn slot_lookup_and_class_slots() {
+    let units_schema = from_yaml(Path::new(&data_path("units.yaml"))).unwrap();
+    let mappings_schema = from_yaml(Path::new(&data_path("mappings.yaml"))).unwrap();
+
+    let mut sv = SchemaView::new();
+    sv.add_schema(units_schema.clone()).unwrap();
+    sv.add_schema(mappings_schema.clone()).unwrap();
+
+    let conv = converter_from_schemas([&units_schema, &mappings_schema]);
+
+    // slot lookup currently returns None as slots are defined inline
+    assert!(sv.get_slot(&Identifier::new("abbreviation"), &conv).unwrap().is_none());
+
+    // class slots with slot_usage
+    let class = sv
+        .get_class(&Identifier::new("UnitOfMeasure"), &conv)
+        .unwrap()
+        .unwrap();
+    let slots = class.slots();
+    let mut map: HashMap<String, usize> = HashMap::new();
+    for s in slots {
+        map.insert(s.name.clone(), s.definitions.len());
+    }
+    assert_eq!(map.get("symbol"), Some(&0usize));
+    assert_eq!(map.get("exact mappings"), Some(&1usize));
+}


### PR DESCRIPTION
## Summary
- cache slot information when constructing `ClassView`
- expose cached slots via `slots()`
- update `SchemaView::get_class` to build cached `ClassView`
- add superclass to `person.yaml` test data
- adjust slot view test for new API

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68554b533bbc8329a20960da19192589