### PR TITLE
Add identifier-based lookups

### DIFF
--- a/src/schemaview/src/identifier.rs
+++ b/src/schemaview/src/identifier.rs
@@ -159,6 +159,26 @@ impl FromStr for Identifier {
     }
 }
 
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Identifier::Uri(u) => write!(f, "{}", u.0),
+            Identifier::Curie(c) => write!(f, "{}", c.0),
+            Identifier::Name(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+impl From<Identifier> for String {
+    fn from(id: Identifier) -> Self {
+        match id {
+            Identifier::Uri(u) => u.0,
+            Identifier::Curie(c) => c.0,
+            Identifier::Name(n) => n,
+        }
+    }
+}
+
 /// Build a [`Converter`] from one or more [`SchemaDefinition`]s.
 ///
 /// All prefixes declared in the schemas are added to the converter. Duplicate

--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -109,7 +109,8 @@ impl SchemaView {
         let conv = converter_from_schema(&schema);
         self.index_schema_classes(&schema_uri, &schema, &conv)
             .map_err(|e| format!("{:?}", e))?;
-        self.schema_definitions.insert(schema_uri.to_string(), schema);
+        self.schema_definitions
+            .insert(schema_uri.to_string(), schema);
         if self.primary_schema.is_none() {
             self.primary_schema = Some(schema_uri.to_string());
         }
@@ -127,9 +128,7 @@ impl SchemaView {
             let default_uri = Identifier::new(&format!("{}:{}", default_prefix, class_name))
                 .to_uri(conv)
                 .map(|u| u.0)
-                .unwrap_or_else(|_| {
-                    format!("{}/{}", schema.id.trim_end_matches('/'), class_name)
-                });
+                .unwrap_or_else(|_| format!("{}/{}", schema.id.trim_end_matches('/'), class_name));
 
             if let Some(curi) = &class_def.class_uri {
                 let explicit_uri = Identifier::new(curi).to_uri(conv)?.0;

--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::identifier::{converter_from_schema, Identifier, IdentifierError};
 use curies::Converter;
-use linkml_meta::{ClassDefinition, SchemaDefinition};
+use linkml_meta::{ClassDefinition, SchemaDefinition, SlotDefinition, TypeDefinition};
 
 use crate::curie::curie2uri;
 
@@ -14,11 +14,84 @@ pub struct SchemaView {
 
 pub struct ClassView<'a> {
     pub class: &'a ClassDefinition,
+    schema: &'a SchemaDefinition,
 }
 
 impl<'a> ClassView<'a> {
-    pub fn new(class: &'a ClassDefinition) -> Self {
-        Self { class }
+    pub fn new(class: &'a ClassDefinition, schema: &'a SchemaDefinition) -> Self {
+        Self { class, schema }
+    }
+
+    pub fn get_uri(
+        &self,
+        conv: &Converter,
+        native: bool,
+        expand: bool,
+    ) -> Result<Identifier, IdentifierError> {
+        let prefix = self
+            .schema
+            .default_prefix
+            .as_deref()
+            .unwrap_or(&self.schema.name);
+        let curie = format!("{}:{}", prefix, self.class.name);
+        let mut id = Identifier::new(&curie);
+        if !native {
+            if let Some(curi) = &self.class.class_uri {
+                id = Identifier::new(curi);
+            }
+        }
+        if expand {
+            Ok(id.to_uri(conv)?.into())
+        } else {
+            Ok(id.to_curie(conv)?.into())
+        }
+    }
+
+    pub fn get_type_designator_value(
+        &self,
+        sv: &SchemaView,
+        slot: &SlotDefinition,
+        conv: &Converter,
+    ) -> Result<Identifier, IdentifierError> {
+        let range = slot.range.as_deref().unwrap_or("string");
+        let types = sv.type_ancestors(&Identifier::new(range));
+        if types.iter().any(|t| t == &Identifier::new("uri")) {
+            self.get_uri(conv, false, true)
+        } else if types.iter().any(|t| t == &Identifier::new("uriorcurie")) {
+            self.get_uri(conv, false, false)
+        } else if types.iter().any(|t| t == &Identifier::new("string")) {
+            Ok(Identifier::Name(self.class.name.clone()))
+        } else {
+            self.get_uri(conv, false, false)
+        }
+    }
+
+    pub fn get_accepted_type_designator_values(
+        &self,
+        sv: &SchemaView,
+        slot: &SlotDefinition,
+        conv: &Converter,
+    ) -> Result<Vec<Identifier>, IdentifierError> {
+        let mut vals = vec![
+            self.get_uri(conv, true, true)?,
+            self.get_uri(conv, false, true)?,
+            self.get_uri(conv, true, false)?,
+            self.get_uri(conv, false, false)?,
+        ];
+        vals.dedup();
+
+        let range = slot.range.as_deref().unwrap_or("string");
+        let types = sv.type_ancestors(&Identifier::new(range));
+        if types
+            .iter()
+            .any(|t| t == &Identifier::new("uri") || t == &Identifier::new("uriorcurie"))
+        {
+            Ok(vals)
+        } else if range == "string" || types.iter().any(|t| t == &Identifier::new("string")) {
+            Ok(vec![Identifier::Name(self.class.name.clone())])
+        } else {
+            Ok(vals)
+        }
     }
 }
 
@@ -112,19 +185,45 @@ impl SchemaView {
                     Some(s) => s,
                     None => return Ok(None),
                 };
-                Ok(schema.classes.get(name).map(|c| ClassView::new(c)))
+                Ok(schema.classes.get(name).map(|c| ClassView::new(c, schema)))
             }
             Identifier::Curie(_) | Identifier::Uri(_) => {
                 let target_uri = id.to_uri(conv)?;
                 if let Some((schema_uri, class_name)) = index.get(&target_uri.0) {
                     if let Some(schema) = self.schema_definitions.get(schema_uri) {
                         if let Some(class) = schema.classes.get(class_name) {
-                            return Ok(Some(ClassView::new(class)));
+                            return Ok(Some(ClassView::new(class, schema)));
                         }
                     }
                 }
                 Ok(None)
             }
         }
+    }
+
+    pub fn get_type<'a>(&'a self, id: &Identifier) -> Option<&'a TypeDefinition> {
+        let key = match id {
+            Identifier::Uri(u) => &u.0,
+            Identifier::Curie(c) => &c.0,
+            Identifier::Name(n) => n,
+        };
+        for schema in self.schema_definitions.values() {
+            if let Some(t) = schema.types.get(key) {
+                return Some(t);
+            }
+        }
+        None
+    }
+
+    pub fn type_ancestors(&self, type_name: &Identifier) -> Vec<Identifier> {
+        let mut ancestors = Vec::new();
+        let mut current = Some(type_name.clone());
+        while let Some(name) = current {
+            ancestors.push(name.clone());
+            current = self
+                .get_type(&name)
+                .and_then(|t| t.typeof_.as_ref().map(|s| Identifier::new(s)));
+        }
+        ancestors
     }
 }

--- a/src/schemaview/tests/class_uri.rs
+++ b/src/schemaview/tests/class_uri.rs
@@ -1,0 +1,54 @@
+use schemaview::identifier::{converter_from_schemas, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn class_get_uri() {
+    let person_schema = from_yaml(Path::new(&data_path("person.yaml"))).unwrap();
+    let container_schema = from_yaml(Path::new(&data_path("container.yaml"))).unwrap();
+
+    let mut sv = SchemaView::new();
+    sv.add_schema(container_schema.clone()).unwrap();
+    sv.add_schema(person_schema.clone()).unwrap();
+
+    let conv = converter_from_schemas([&person_schema, &container_schema]);
+
+    let person = sv
+        .get_class(&Identifier::new("personinfo:Person"), &conv)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        person.get_uri(&conv, false, false).unwrap().to_string(),
+        "linkml:Person"
+    );
+    assert_eq!(
+        person.get_uri(&conv, true, false).unwrap().to_string(),
+        "personinfo:Person"
+    );
+    assert_eq!(
+        person.get_uri(&conv, false, true).unwrap().to_string(),
+        "https://w3id.org/linkml/Person"
+    );
+
+    let container = sv
+        .get_class(&Identifier::new("Container"), &conv)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        container.get_uri(&conv, false, false).unwrap().to_string(),
+        "container:Container"
+    );
+    assert_eq!(
+        container.get_uri(&conv, true, false).unwrap().to_string(),
+        "container:Container"
+    );
+}


### PR DESCRIPTION
## Summary
- implement `Display` and `From<Identifier> for String`
- return `Identifier` from class URI helpers
- use `Identifier` for schema type lookups
- update URI tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685550812f488329a237a1e71d70064e