### PR TITLE
Expose SchemaView to Python

### DIFF
--- a/src/schemaview/Cargo.toml
+++ b/src/schemaview/Cargo.toml
@@ -9,9 +9,12 @@ name = "schemaview"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = "0.25.0"
-linkml_meta = { path = "../metamodel"}
+pyo3 = { version = "0.25.0", optional = true }
+linkml_meta = { path = "../metamodel" }
 serde_yml = "0.0.12"
 serde_path_to_error = "0.1.17"
 reqwest = { version = "0.12.16" , features = ["blocking"] }
 curies = "0.1.3"
+
+[features]
+python = ["pyo3", "linkml_meta/pyo3"]

--- a/src/schemaview/src/lib.rs
+++ b/src/schemaview/src/lib.rs
@@ -4,17 +4,53 @@ pub mod curie;
 pub mod resolve;
 pub mod identifier;
 extern crate linkml_meta;
+
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use std::path::Path;
+#[cfg(feature = "python")]
+use pyo3::exceptions::PyException;
+use crate::schemaview::SchemaView as RustSchemaView;
 
 /// Formats the sum of two numbers as string.
+#[cfg(feature = "python")]
 #[pyfunction]
 fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
     Ok((a + b).to_string())
 }
 
+#[cfg(feature = "python")]
+#[pyclass(name = "SchemaView")]
+pub struct PySchemaView {
+    inner: RustSchemaView,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PySchemaView {
+    #[new]
+    fn new(path: Option<&str>) -> PyResult<Self> {
+        let mut sv = RustSchemaView::new();
+        if let Some(p) = path {
+            let schema = crate::io::from_yaml(Path::new(p))
+                .map_err(|e| PyException::new_err(e.to_string()))?;
+            sv.add_schema(schema)
+                .map_err(|e| PyException::new_err(e))?;
+        }
+        Ok(Self { inner: sv })
+    }
+
+    fn get_unresolved_schemas(&self) -> Vec<String> {
+        self.inner.get_unresolved_schemas()
+    }
+}
+
 /// A Python module implemented in Rust.
+#[cfg(feature = "python")]
 #[pymodule(name="schemaview")]
-fn schemaview_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn schemaview_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
+    m.add_class::<PySchemaView>()?;
     Ok(())
 }

--- a/src/schemaview/tests/python_api.rs
+++ b/src/schemaview/tests/python_api.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "python")]
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use std::path::PathBuf;
+use schemaview::schemaview_module;
+
+fn meta_path() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push("meta.yaml");
+    p
+}
+
+#[test]
+fn construct_via_python() {
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let module = PyModule::new(py, "schemaview").unwrap();
+        schemaview_module(&module).unwrap();
+        let sys = py.import("sys").unwrap();
+        let modules = sys.getattr("modules").unwrap();
+        let sys_modules = modules.downcast::<PyDict>().unwrap();
+        sys_modules.set_item("schemaview", module).unwrap();
+
+        let locals = PyDict::new(py);
+        locals.set_item("meta_path", meta_path().to_str().unwrap()).unwrap();
+        pyo3::py_run!(py, *locals, r#"
+import schemaview
+sv = schemaview.SchemaView(meta_path)
+unresolved = sv.get_unresolved_schemas()
+assert "https://w3id.org/linkml/mappings" in unresolved
+"#);
+    });
+}


### PR DESCRIPTION
## Summary
- expose `SchemaView` as a `#[pyclass]` behind a `python` feature
- forward the feature to `linkml_meta`
- provide a Python test running real code via `py_run!`

## Testing
- `cargo test --all --features python`


------
https://chatgpt.com/codex/tasks/task_e_6855511e8dc483299831291b9e0316f2