### PR TITLE
Add identifier-based lookups

### DIFF
--- a/src/schemaview/src/identifier.rs
+++ b/src/schemaview/src/identifier.rs
@@ -159,6 +159,26 @@ impl FromStr for Identifier {
     }
 }
 
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Identifier::Uri(u) => write!(f, "{}", u.0),
+            Identifier::Curie(c) => write!(f, "{}", c.0),
+            Identifier::Name(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+impl From<Identifier> for String {
+    fn from(id: Identifier) -> Self {
+        match id {
+            Identifier::Uri(u) => u.0,
+            Identifier::Curie(c) => c.0,
+            Identifier::Name(n) => n,
+        }
+    }
+}
+
 /// Build a [`Converter`] from one or more [`SchemaDefinition`]s.
 ///
 /// All prefixes declared in the schemas are added to the converter. Duplicate

--- a/src/schemaview/tests/class_uri.rs
+++ b/src/schemaview/tests/class_uri.rs
@@ -1,0 +1,54 @@
+use schemaview::identifier::{converter_from_schemas, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn class_get_uri() {
+    let person_schema = from_yaml(Path::new(&data_path("person.yaml"))).unwrap();
+    let container_schema = from_yaml(Path::new(&data_path("container.yaml"))).unwrap();
+
+    let mut sv = SchemaView::new();
+    sv.add_schema(container_schema.clone()).unwrap();
+    sv.add_schema(person_schema.clone()).unwrap();
+
+    let conv = converter_from_schemas([&person_schema, &container_schema]);
+
+    let person = sv
+        .get_class(&Identifier::new("personinfo:Person"), &conv)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        person.get_uri(&conv, false, false).unwrap().to_string(),
+        "linkml:Person"
+    );
+    assert_eq!(
+        person.get_uri(&conv, true, false).unwrap().to_string(),
+        "personinfo:Person"
+    );
+    assert_eq!(
+        person.get_uri(&conv, false, true).unwrap().to_string(),
+        "https://w3id.org/linkml/Person"
+    );
+
+    let container = sv
+        .get_class(&Identifier::new("Container"), &conv)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        container.get_uri(&conv, false, false).unwrap().to_string(),
+        "container:Container"
+    );
+    assert_eq!(
+        container.get_uri(&conv, true, false).unwrap().to_string(),
+        "container:Container"
+    );
+}


### PR DESCRIPTION
## Summary
- implement `Display` and `From<Identifier> for String`
- return `Identifier` from class URI helpers
- use `Identifier` for schema type lookups
- update URI tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685550812f488329a237a1e71d70064e