### PR TITLE
Add schema-aware runtime validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +203,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
@@ -693,6 +789,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +849,16 @@ dependencies = [
  "serde-value",
  "serde_path_to_error",
  "serde_yml",
+]
+
+[[package]]
+name = "linkml_runtime"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "schemaview",
+ "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -860,6 +972,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -1447,6 +1565,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serde_yml"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1761,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1910,6 +2047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,6 +2074,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members=[
     "src/main",
     "src/metamodel",
     "src/schemaview",
+    "src/runtime",
 ]
 resolver = "2"
 version="0.1.0"

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "linkml_runtime"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "linkml_runtime"
+
+[[bin]]
+name = "linkml-validate"
+path = "src/bin/linkml_validate.rs"
+
+[[bin]]
+name = "linkml-convert"
+path = "src/bin/linkml_convert.rs"
+
+[dependencies]
+schemaview = { path = "../schemaview" }
+serde_json = "1.0"
+serde_yaml = "0.9"
+clap = { version = "4.5", features = ["derive"] }

--- a/src/runtime/src/bin/linkml_convert.rs
+++ b/src/runtime/src/bin/linkml_convert.rs
@@ -1,0 +1,3 @@
+fn main() {
+    eprintln!("linkml-convert is not implemented yet");
+}

--- a/src/runtime/src/bin/linkml_validate.rs
+++ b/src/runtime/src/bin/linkml_validate.rs
@@ -1,0 +1,48 @@
+use clap::Parser;
+use linkml_runtime::{load_json_file, load_yaml_file, validate};
+use schemaview::identifier::{converter_from_schema, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::SchemaView;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+struct Args {
+    /// LinkML schema YAML file
+    schema: PathBuf,
+    /// Name of the class to validate against
+    class: String,
+    /// Data file (YAML or JSON)
+    data: PathBuf,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let schema = from_yaml(&args.schema)?;
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).map_err(|e| format!("{e}"))?;
+    let conv = converter_from_schema(&schema);
+    let class_view = sv
+        .get_class(&Identifier::new(&args.class), &conv)
+        .map_err(|e| format!("{e:?}"))?
+        .ok_or("class not found")?;
+    let data_path = &args.data;
+    let value = if let Some(ext) = data_path.extension() {
+        if ext == "json" {
+            load_json_file(data_path, &sv, Some(&class_view))?
+        } else {
+            load_yaml_file(data_path, &sv, Some(&class_view))?
+        }
+    } else {
+        load_yaml_file(data_path, &sv, Some(&class_view))?
+    };
+    match validate(&value) {
+        Ok(_) => {
+            println!("valid");
+            Ok(())
+        }
+        Err(e) => {
+            println!("invalid: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -1,0 +1,105 @@
+use schemaview::schemaview::{ClassView, SchemaView, SlotView};
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+pub enum LinkMLValue<'a> {
+    Scalar {
+        value: JsonValue,
+        slot: Option<&'a SlotView<'a>>,
+        sv: &'a SchemaView,
+    },
+    List {
+        values: Vec<LinkMLValue<'a>>,
+        slot: Option<&'a SlotView<'a>>,
+        sv: &'a SchemaView,
+    },
+    Map {
+        values: HashMap<String, LinkMLValue<'a>>,
+        class: Option<&'a ClassView<'a>>,
+        sv: &'a SchemaView,
+    },
+}
+
+impl<'a> LinkMLValue<'a> {
+    fn from_json(
+        value: JsonValue,
+        class: Option<&'a ClassView<'a>>,
+        slot: Option<&'a SlotView<'a>>,
+        sv: &'a SchemaView,
+    ) -> Self {
+        match value {
+            JsonValue::Array(arr) => {
+                let values = arr
+                    .into_iter()
+                    .map(|v| LinkMLValue::from_json(v, None, None, sv))
+                    .collect();
+                LinkMLValue::List { values, slot, sv }
+            }
+            JsonValue::Object(map) => {
+                let mut values = HashMap::new();
+                for (k, v) in map.into_iter() {
+                    let slot_ref = class
+                        .and_then(|cv| cv.slots().iter().find(|s| s.name == k));
+                    values.insert(k, LinkMLValue::from_json(v, None, slot_ref, sv));
+                }
+                LinkMLValue::Map { values, class, sv }
+            }
+            other => LinkMLValue::Scalar { value: other, slot, sv },
+        }
+    }
+}
+
+pub fn load_yaml_file<'a>(
+    path: &Path,
+    sv: &'a SchemaView,
+    class: Option<&'a ClassView<'a>>,
+) -> Result<LinkMLValue<'a>, Box<dyn std::error::Error>> {
+    let text = fs::read_to_string(path)?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&text)?;
+    let json = serde_json::to_value(value)?;
+    Ok(LinkMLValue::from_json(json, class, None, sv))
+}
+
+pub fn load_json_file<'a>(
+    path: &Path,
+    sv: &'a SchemaView,
+    class: Option<&'a ClassView<'a>>,
+) -> Result<LinkMLValue<'a>, Box<dyn std::error::Error>> {
+    let text = fs::read_to_string(path)?;
+    let value: JsonValue = serde_json::from_str(&text)?;
+    Ok(LinkMLValue::from_json(value, class, None, sv))
+}
+
+fn validate_inner<'a>(value: &LinkMLValue<'a>) -> Result<(), String> {
+    match value {
+        LinkMLValue::Scalar { .. } => Ok(()),
+        LinkMLValue::List { values, .. } => {
+            for v in values {
+                validate_inner(v)?;
+            }
+            Ok(())
+        }
+        LinkMLValue::Map { values, class, .. } => {
+            if let Some(cv) = class {
+                for (k, v) in values {
+                    if cv.slots().iter().all(|s| s.name != *k) {
+                        return Err(format!("unknown slot `{}`", k));
+                    }
+                    validate_inner(v)?;
+                }
+            } else {
+                for v in values.values() {
+                    validate_inner(v)?;
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+pub fn validate<'a>(value: &LinkMLValue<'a>) -> Result<(), String> {
+    validate_inner(value)
+}
+

--- a/src/runtime/tests/basic.rs
+++ b/src/runtime/tests/basic.rs
@@ -1,0 +1,41 @@
+use linkml_runtime::{load_yaml_file, validate};
+use schemaview::identifier::{converter_from_schema, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn validate_person_ok() {
+    let schema = from_yaml(Path::new(&data_path("schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Person"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let v = load_yaml_file(Path::new(&data_path("person_valid.yaml")), &sv, Some(&class)).unwrap();
+    assert!(validate(&v).is_ok());
+}
+
+#[test]
+fn validate_person_fail() {
+    let schema = from_yaml(Path::new(&data_path("schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Person"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let v = load_yaml_file(Path::new(&data_path("person_invalid.yaml")), &sv, Some(&class)).unwrap();
+    assert!(validate(&v).is_err());
+}

--- a/src/runtime/tests/data/person_invalid.yaml
+++ b/src/runtime/tests/data/person_invalid.yaml
@@ -1,0 +1,3 @@
+name: Bob
+age: 25
+extra: foo

--- a/src/runtime/tests/data/person_valid.yaml
+++ b/src/runtime/tests/data/person_valid.yaml
@@ -1,0 +1,2 @@
+name: Alice
+age: 33

--- a/src/runtime/tests/data/schema.yaml
+++ b/src/runtime/tests/data/schema.yaml
@@ -1,0 +1,10 @@
+id: https://example.com/test
+name: test
+prefixes:
+  test: https://example.com/test/
+default_prefix: test
+classes:
+  Person:
+    attributes:
+      name:
+      age:


### PR DESCRIPTION
## Summary
- enhance `LinkMLValue` with schema/slot references
- rename `validate_with_schema` -> `validate` and store `SchemaView` in each value
- switch `linkml-validate` to clap for argument parsing
- adjust tests for new API and add clap dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68555844cda08329aba5e1ca46c783eb