### PR TITLE
Add class URI helpers and identifier display

### DIFF
--- a/src/schemaview/src/identifier.rs
+++ b/src/schemaview/src/identifier.rs
@@ -159,6 +159,26 @@ impl FromStr for Identifier {
     }
 }
 
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Identifier::Uri(u) => write!(f, "{}", u.0),
+            Identifier::Curie(c) => write!(f, "{}", c.0),
+            Identifier::Name(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+impl From<Identifier> for String {
+    fn from(id: Identifier) -> Self {
+        match id {
+            Identifier::Uri(u) => u.0,
+            Identifier::Curie(c) => c.0,
+            Identifier::Name(n) => n,
+        }
+    }
+}
+
 /// Build a [`Converter`] from one or more [`SchemaDefinition`]s.
 ///
 /// All prefixes declared in the schemas are added to the converter. Duplicate

--- a/src/schemaview/tests/class_uri.rs
+++ b/src/schemaview/tests/class_uri.rs
@@ -1,0 +1,32 @@
+use schemaview::identifier::{converter_from_schemas, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn class_get_uri() {
+    let person_schema = from_yaml(Path::new(&data_path("person.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(person_schema.clone()).unwrap();
+    let conv = converter_from_schemas([&person_schema]);
+    let cv = sv
+        .get_class(&Identifier::new("Person"), &conv)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        cv.get_uri(&conv, false, false).unwrap().to_string(),
+        "linkml:Person"
+    );
+    assert_eq!(
+        cv.get_uri(&conv, true, false).unwrap().to_string(),
+        "personinfo:Person"
+    );
+}


### PR DESCRIPTION
## Summary
- add `Display` and `From<String>` impls for `Identifier`
- store schema reference in `ClassView`
- add URI helper and type designator logic
- expose `type_ancestors` on `SchemaView`
- test getting URIs from `ClassView`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68555e37e7c88329bd2276fe08471595