### PR TITLE
Implement runtime polymorphism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,7 @@ name = "linkml_runtime"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "curies",
  "schemaview",
  "serde_json",
  "serde_yaml",

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -19,3 +19,4 @@ schemaview = { path = "../schemaview" }
 serde_json = "1.0"
 serde_yaml = "0.9"
 clap = { version = "4.5", features = ["derive"] }
+curies = "0.1.3"

--- a/src/runtime/src/bin/linkml_validate.rs
+++ b/src/runtime/src/bin/linkml_validate.rs
@@ -28,12 +28,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data_path = &args.data;
     let value = if let Some(ext) = data_path.extension() {
         if ext == "json" {
-            load_json_file(data_path, &sv, Some(&class_view))?
+            load_json_file(data_path, &sv, Some(&class_view), &conv)?
         } else {
-            load_yaml_file(data_path, &sv, Some(&class_view))?
+            load_yaml_file(data_path, &sv, Some(&class_view), &conv)?
         }
     } else {
-        load_yaml_file(data_path, &sv, Some(&class_view))?
+        load_yaml_file(data_path, &sv, Some(&class_view), &conv)?
     };
     match validate(&value) {
         Ok(_) => {

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -1,5 +1,7 @@
 use schemaview::schemaview::{ClassView, SchemaView, SlotView};
+use schemaview::identifier::Identifier;
 use serde_json::Value as JsonValue;
+use curies::Converter;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
@@ -23,28 +25,103 @@ pub enum LinkMLValue<'a> {
 }
 
 impl<'a> LinkMLValue<'a> {
+    fn select_class(
+        map: &serde_json::Map<String, JsonValue>,
+        base: &'a ClassView<'a>,
+        sv: &'a SchemaView,
+        conv: &Converter,
+    ) -> &'a ClassView<'a> {
+        let base_box = Box::leak(Box::new(base.clone()));
+        let mut cands: Vec<&'a ClassView<'a>> = vec![base_box];
+        if let Ok(desc) = base_box.get_descendants(conv, true) {
+            for d in desc.into_iter() {
+                cands.push(Box::leak(Box::new(d)));
+            }
+        }
+
+        let mut preferred: Option<&ClassView<'a>> = None;
+        if let Some(ts) = base_box
+            .slots()
+            .iter()
+            .find(|s| s.definitions.iter().rev().any(|d| d.designates_type.unwrap_or(false)))
+        {
+            if let Some(JsonValue::String(tv)) = map.get(&ts.name) {
+                if let Some(def) = ts.definitions.iter().rev().find(|d| d.designates_type.unwrap_or(false)) {
+                    for c in &cands {
+                        if let Ok(vals) = c.get_accepted_type_designator_values(def, conv) {
+                            if vals.iter().any(|v| v.to_string() == *tv) {
+                                preferred = Some(*c);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(p) = preferred {
+            return p;
+        }
+
+        for c in &cands {
+            let tmp = LinkMLValue::from_json(JsonValue::Object(map.clone()), Some(*c), None, sv, conv, false);
+            if validate(&tmp).is_ok() {
+                return *c;
+            }
+        }
+
+        base_box
+    }
     fn from_json(
         value: JsonValue,
         class: Option<&'a ClassView<'a>>,
         slot: Option<&'a SlotView<'a>>,
         sv: &'a SchemaView,
+        conv: &Converter,
+        polymorphic: bool,
     ) -> Self {
         match value {
             JsonValue::Array(arr) => {
                 let values = arr
                     .into_iter()
-                    .map(|v| LinkMLValue::from_json(v, None, None, sv))
+                    .map(|v| LinkMLValue::from_json(v, None, None, sv, conv, true))
                     .collect();
                 LinkMLValue::List { values, slot, sv }
             }
             JsonValue::Object(map) => {
+                if !polymorphic && slot.is_none() {
+                    if let Some(cls) = class {
+                        let mut values = HashMap::new();
+                        for (k, v) in map.into_iter() {
+                            let slot_ref = cls.slots().iter().find(|s| s.name == k);
+                            values.insert(k, LinkMLValue::from_json(v, None, slot_ref, sv, conv, true));
+                        }
+                        return LinkMLValue::Map { values, class: Some(cls), sv };
+                    }
+                }
+
+                // determine base class
+                let base_class_ref: Option<&'a ClassView<'a>> = match class {
+                    Some(c) => Some(Box::leak(Box::new(c.clone())) as &'a ClassView<'a>),
+                    None => slot.and_then(|s| {
+                        s.definitions
+                            .iter()
+                            .rev()
+                            .find_map(|d| d.range.as_deref())
+                            .and_then(|r| sv.get_class(&Identifier::new(r), conv).ok().flatten())
+                            .map(|cls| Box::leak(Box::new(cls)) as &'a ClassView<'a>)
+                    }),
+                };
+
+                let chosen_ref: Option<&'a ClassView<'a>> =
+                    base_class_ref.map(|b| Self::select_class(&map, b, sv, conv));
+
                 let mut values = HashMap::new();
                 for (k, v) in map.into_iter() {
-                    let slot_ref = class
+                    let slot_ref = chosen_ref
                         .and_then(|cv| cv.slots().iter().find(|s| s.name == k));
-                    values.insert(k, LinkMLValue::from_json(v, None, slot_ref, sv));
+                    values.insert(k, LinkMLValue::from_json(v, None, slot_ref, sv, conv, true));
                 }
-                LinkMLValue::Map { values, class, sv }
+                LinkMLValue::Map { values, class: chosen_ref, sv }
             }
             other => LinkMLValue::Scalar { value: other, slot, sv },
         }
@@ -55,21 +132,23 @@ pub fn load_yaml_file<'a>(
     path: &Path,
     sv: &'a SchemaView,
     class: Option<&'a ClassView<'a>>,
+    conv: &Converter,
 ) -> Result<LinkMLValue<'a>, Box<dyn std::error::Error>> {
     let text = fs::read_to_string(path)?;
     let value: serde_yaml::Value = serde_yaml::from_str(&text)?;
     let json = serde_json::to_value(value)?;
-    Ok(LinkMLValue::from_json(json, class, None, sv))
+    Ok(LinkMLValue::from_json(json, class, None, sv, conv, true))
 }
 
 pub fn load_json_file<'a>(
     path: &Path,
     sv: &'a SchemaView,
     class: Option<&'a ClassView<'a>>,
+    conv: &Converter,
 ) -> Result<LinkMLValue<'a>, Box<dyn std::error::Error>> {
     let text = fs::read_to_string(path)?;
     let value: JsonValue = serde_json::from_str(&text)?;
-    Ok(LinkMLValue::from_json(value, class, None, sv))
+    Ok(LinkMLValue::from_json(value, class, None, sv, conv, true))
 }
 
 fn validate_inner<'a>(value: &LinkMLValue<'a>) -> Result<(), String> {

--- a/src/runtime/tests/basic.rs
+++ b/src/runtime/tests/basic.rs
@@ -22,7 +22,13 @@ fn validate_person_ok() {
         .get_class(&Identifier::new("Person"), &conv)
         .unwrap()
         .expect("class not found");
-    let v = load_yaml_file(Path::new(&data_path("person_valid.yaml")), &sv, Some(&class)).unwrap();
+    let v = load_yaml_file(
+        Path::new(&data_path("person_valid.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
     assert!(validate(&v).is_ok());
 }
 
@@ -36,6 +42,12 @@ fn validate_person_fail() {
         .get_class(&Identifier::new("Person"), &conv)
         .unwrap()
         .expect("class not found");
-    let v = load_yaml_file(Path::new(&data_path("person_invalid.yaml")), &sv, Some(&class)).unwrap();
+    let v = load_yaml_file(
+        Path::new(&data_path("person_invalid.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
     assert!(validate(&v).is_err());
 }

--- a/src/runtime/tests/data/poly_schema.yaml
+++ b/src/runtime/tests/data/poly_schema.yaml
@@ -1,0 +1,21 @@
+id: https://example.com/poly
+name: poly
+prefixes:
+  poly: https://example.com/poly/
+default_prefix: poly
+classes:
+  Parent:
+    attributes:
+      type:
+        designates_type: true
+        range: string
+      id:
+  Child:
+    is_a: Parent
+    attributes:
+      extra:
+  Container:
+    tree_root: true
+    attributes:
+      obj:
+        range: Parent

--- a/src/runtime/tests/data/poly_with_type.yaml
+++ b/src/runtime/tests/data/poly_with_type.yaml
@@ -1,0 +1,4 @@
+obj:
+  type: Child
+  id: P1
+  extra: foo

--- a/src/runtime/tests/data/poly_without_type.yaml
+++ b/src/runtime/tests/data/poly_without_type.yaml
@@ -1,0 +1,3 @@
+obj:
+  id: P2
+  extra: bar

--- a/src/runtime/tests/data/root_with_type.yaml
+++ b/src/runtime/tests/data/root_with_type.yaml
@@ -1,0 +1,3 @@
+type: Child
+id: R1
+extra: q

--- a/src/runtime/tests/data/root_without_type.yaml
+++ b/src/runtime/tests/data/root_without_type.yaml
@@ -1,0 +1,2 @@
+id: R2
+extra: z

--- a/src/runtime/tests/polymorphic.rs
+++ b/src/runtime/tests/polymorphic.rs
@@ -1,0 +1,93 @@
+use linkml_runtime::{load_yaml_file, validate};
+use schemaview::identifier::{converter_from_schema, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn polymorphism_with_type() {
+    let schema = from_yaml(Path::new(&data_path("poly_schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Container"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let v = load_yaml_file(
+        Path::new(&data_path("poly_with_type.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
+    assert!(validate(&v).is_ok());
+}
+
+#[test]
+fn polymorphism_without_type() {
+    let schema = from_yaml(Path::new(&data_path("poly_schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Container"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let v = load_yaml_file(
+        Path::new(&data_path("poly_without_type.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
+    assert!(validate(&v).is_ok());
+}
+
+#[test]
+fn root_polymorphism_with_type() {
+    let schema = from_yaml(Path::new(&data_path("poly_schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Parent"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let v = load_yaml_file(
+        Path::new(&data_path("root_with_type.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
+    assert!(validate(&v).is_ok());
+}
+
+#[test]
+fn root_polymorphism_without_type() {
+    let schema = from_yaml(Path::new(&data_path("poly_schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Parent"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let v = load_yaml_file(
+        Path::new(&data_path("root_without_type.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
+    assert!(validate(&v).is_ok());
+}


### PR DESCRIPTION
## Summary
- add `get_descendants` to `ClassView`
- support polymorphic class loading in runtime using type designators
- extend command line validator and tests
- add data for new polymorphic tests
- handle subclass resolution at root level

## Testing
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_685564faddc883299a6621054300349e