### PR TITLE
Add slot and class utilities

### DIFF
--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -6,6 +6,20 @@ use linkml_meta::{ClassDefinition, SchemaDefinition, SlotDefinition};
 
 use crate::curie::curie2uri;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotContainerMode {
+    SingleValue,
+    Mapping,
+    List,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotInlineMode {
+    Inline,
+    Primitive,
+    Reference,
+}
+
 pub struct SchemaView {
     schema_definitions: HashMap<String, SchemaDefinition>,
     primary_schema: Option<String>,
@@ -232,6 +246,19 @@ impl<'a> ClassView<'a> {
         }
         Ok(out)
     }
+
+    pub fn key_or_identifier_slot(&'a self) -> Option<&'a SlotView<'a>> {
+        self.slots.iter().find(|s| {
+            let d = s.merged_definition();
+            d.identifier.unwrap_or(false) || d.key.unwrap_or(false)
+        })
+    }
+
+    pub fn identifier_slot(&'a self) -> Option<&'a SlotView<'a>> {
+        self.slots
+            .iter()
+            .find(|s| s.merged_definition().identifier.unwrap_or(false))
+    }
 }
 
 #[derive(Clone)]
@@ -246,6 +273,129 @@ impl<'a> SlotView<'a> {
             name,
             definitions: vec![slot],
         }
+    }
+
+    pub fn merged_definition(&self) -> SlotDefinition {
+        let mut base = self.definitions[0].clone();
+        for d in self.definitions.iter().skip(1) {
+            if let Some(v) = &d.range {
+                base.range = Some(v.clone());
+            }
+            if let Some(v) = d.multivalued {
+                base.multivalued = Some(v);
+            }
+            if let Some(v) = d.inlined {
+                base.inlined = Some(v);
+            }
+            if let Some(v) = d.inlined_as_list {
+                base.inlined_as_list = Some(v);
+            }
+            if let Some(v) = d.key {
+                base.key = Some(v);
+            }
+            if let Some(v) = d.identifier {
+                base.identifier = Some(v);
+            }
+        }
+        base
+    }
+
+    pub fn determine_slot_mode(
+        &self,
+        sv: &'a SchemaView,
+        conv: &Converter,
+    ) -> (SlotContainerMode, SlotInlineMode) {
+        let s = self.merged_definition();
+        let multivalued = s.multivalued.unwrap_or(false);
+        let class_range = match &s.range {
+            Some(r) => sv
+                .get_class(&Identifier::new(r), conv)
+                .ok()
+                .flatten()
+                .is_some(),
+            None => false,
+        };
+
+        if !class_range {
+            return (
+                if multivalued {
+                    SlotContainerMode::List
+                } else {
+                    SlotContainerMode::SingleValue
+                },
+                SlotInlineMode::Primitive,
+            );
+        }
+
+        if multivalued && s.inlined_as_list.unwrap_or(false) {
+            return (SlotContainerMode::List, SlotInlineMode::Inline);
+        }
+
+        let range_cv = s
+            .range
+            .as_ref()
+            .and_then(|r| sv.get_class(&Identifier::new(r), conv).ok().flatten());
+        let key_slot = range_cv.as_ref().and_then(|cv| cv.key_or_identifier_slot());
+        let identifier_slot = range_cv.as_ref().and_then(|cv| cv.identifier_slot());
+
+        let mut inlined = s.inlined.unwrap_or(false);
+        if identifier_slot.is_none() {
+            inlined = true;
+        }
+
+        if !multivalued {
+            return (
+                SlotContainerMode::SingleValue,
+                if inlined {
+                    SlotInlineMode::Inline
+                } else {
+                    SlotInlineMode::Reference
+                },
+            );
+        }
+
+        if !inlined {
+            return (SlotContainerMode::List, SlotInlineMode::Reference);
+        }
+
+        if key_slot.is_some() {
+            (SlotContainerMode::Mapping, SlotInlineMode::Inline)
+        } else {
+            (SlotContainerMode::List, SlotInlineMode::Inline)
+        }
+    }
+
+    pub fn can_contain_reference_to_class(
+        &self,
+        cls: &ClassView<'a>,
+        sv: &'a SchemaView,
+        conv: &Converter,
+    ) -> bool {
+        let mut classes_to_check = match self.merged_definition().range {
+            Some(r) => vec![r],
+            None => return false,
+        };
+        let mut seen = HashSet::new();
+        let target = &cls.class.name;
+
+        while let Some(c) = classes_to_check.pop() {
+            if !seen.insert(c.clone()) {
+                continue;
+            }
+            if let Ok(Some(cv)) = sv.get_class(&Identifier::new(&c), conv) {
+                if cv.class.name == *target {
+                    return true;
+                }
+                for slot in cv.slots() {
+                    if let Some(r) = &slot.merged_definition().range {
+                        if !seen.contains(r) {
+                            classes_to_check.push(r.clone());
+                        }
+                    }
+                }
+            }
+        }
+        false
     }
 }
 


### PR DESCRIPTION
## Summary
- refine slot mode into container and inline modes
- support slot patching and mode determination
- add helpers on ClassView and SlotView for reference detection

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685570d5f9e88329bd9813cee6d1a542