### PR TITLE
Split determine_slot_mode

### DIFF
--- a/src/schemaview/tests/data/modes_schema.yaml
+++ b/src/schemaview/tests/data/modes_schema.yaml
@@ -1,0 +1,31 @@
+id: http://example.com/test
+name: test
+prefixes:
+  test: http://example.com/test/
+default_prefix: test
+classes:
+  Person:
+    attributes:
+      id:
+        identifier: true
+      name:
+  Container:
+    attributes:
+      persons:
+        range: Person
+        multivalued: true
+        inlined_as_list: true
+      best_friend:
+        range: Person
+        inlined: false
+  Ext:
+    attributes:
+      tag:
+        key: true
+      val:
+  Holder:
+    attributes:
+      exts:
+        range: Ext
+        multivalued: true
+        inlined: true

--- a/src/schemaview/tests/slot_mode.rs
+++ b/src/schemaview/tests/slot_mode.rs
@@ -1,0 +1,89 @@
+use schemaview::identifier::{converter_from_schemas, Identifier};
+use schemaview::io::from_yaml;
+use schemaview::schemaview::{SchemaView, SlotContainerMode, SlotInlineMode};
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn test_slot_modes() {
+    let schema = from_yaml(Path::new(&data_path("modes_schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schemas([&schema]);
+
+    let container = sv
+        .get_class(&Identifier::new("Container"), &conv)
+        .unwrap()
+        .unwrap();
+    let persons_slot = container
+        .slots()
+        .iter()
+        .find(|s| s.name == "persons")
+        .unwrap();
+    assert_eq!(
+        persons_slot.determine_slot_container_mode(&sv, &conv),
+        SlotContainerMode::List
+    );
+    assert_eq!(
+        persons_slot.determine_slot_inline_mode(&sv, &conv),
+        SlotInlineMode::Inline
+    );
+
+    let best_friend = container
+        .slots()
+        .iter()
+        .find(|s| s.name == "best_friend")
+        .unwrap();
+    assert_eq!(
+        best_friend.determine_slot_container_mode(&sv, &conv),
+        SlotContainerMode::SingleValue
+    );
+    assert_eq!(
+        best_friend.determine_slot_inline_mode(&sv, &conv),
+        SlotInlineMode::Reference
+    );
+
+    let person = sv
+        .get_class(&Identifier::new("Person"), &conv)
+        .unwrap()
+        .unwrap();
+    let name_slot = person
+        .slots()
+        .iter()
+        .find(|s| s.name == "name")
+        .unwrap();
+    assert_eq!(
+        name_slot.determine_slot_container_mode(&sv, &conv),
+        SlotContainerMode::SingleValue
+    );
+    assert_eq!(
+        name_slot.determine_slot_inline_mode(&sv, &conv),
+        SlotInlineMode::Primitive
+    );
+
+    let holder = sv
+        .get_class(&Identifier::new("Holder"), &conv)
+        .unwrap()
+        .unwrap();
+    let exts_slot = holder
+        .slots()
+        .iter()
+        .find(|s| s.name == "exts")
+        .unwrap();
+    assert_eq!(
+        exts_slot.determine_slot_container_mode(&sv, &conv),
+        SlotContainerMode::Mapping
+    );
+    assert_eq!(
+        exts_slot.determine_slot_inline_mode(&sv, &conv),
+        SlotInlineMode::Inline
+    );
+}
+


### PR DESCRIPTION
## Summary
- break `determine_slot_mode` into `determine_slot_container_mode` and `determine_slot_inline_mode`
- add regression tests for slot mode calculations

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685573f1ce0c8329b094ee73681824b5