### PR TITLE
Extend Python API with schema access

### DIFF
--- a/src/schemaview/src/lib.rs
+++ b/src/schemaview/src/lib.rs
@@ -1,17 +1,26 @@
-pub mod io;
-pub mod schemaview;
 pub mod curie;
-pub mod resolve;
 pub mod identifier;
+pub mod io;
+pub mod resolve;
+pub mod schemaview;
 extern crate linkml_meta;
 
 #[cfg(feature = "python")]
-use pyo3::prelude::*;
+use crate::identifier::{converter_from_schemas, Identifier};
 #[cfg(feature = "python")]
-use std::path::Path;
+use crate::schemaview::SchemaView as RustSchemaView;
+#[cfg(feature = "python")]
+use linkml_meta::{ClassDefinition, SchemaDefinition};
 #[cfg(feature = "python")]
 use pyo3::exceptions::PyException;
-use crate::schemaview::SchemaView as RustSchemaView;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use serde_path_to_error;
+#[cfg(feature = "python")]
+use serde_yml;
+#[cfg(feature = "python")]
+use std::path::Path;
 
 /// Formats the sum of two numbers as string.
 #[cfg(feature = "python")]
@@ -30,27 +39,59 @@ pub struct PySchemaView {
 #[pymethods]
 impl PySchemaView {
     #[new]
+    #[pyo3(signature = (path=None))]
     fn new(path: Option<&str>) -> PyResult<Self> {
         let mut sv = RustSchemaView::new();
         if let Some(p) = path {
             let schema = crate::io::from_yaml(Path::new(p))
                 .map_err(|e| PyException::new_err(e.to_string()))?;
-            sv.add_schema(schema)
-                .map_err(|e| PyException::new_err(e))?;
+            sv.add_schema(schema).map_err(|e| PyException::new_err(e))?;
         }
         Ok(Self { inner: sv })
+    }
+
+    fn add_schema_from_path(&mut self, path: &str) -> PyResult<()> {
+        let schema = crate::io::from_yaml(Path::new(path))
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+        self.inner
+            .add_schema(schema)
+            .map_err(|e| PyException::new_err(e))
+    }
+
+    fn add_schema_str(&mut self, data: &str) -> PyResult<()> {
+        let deser = serde_yml::Deserializer::from_str(data);
+        let schema: SchemaDefinition = serde_path_to_error::deserialize(deser)
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+        self.inner
+            .add_schema(schema)
+            .map_err(|e| PyException::new_err(e))
     }
 
     fn get_unresolved_schemas(&self) -> Vec<String> {
         self.inner.get_unresolved_schemas()
     }
+
+    fn get_schema(&self, uri: &str) -> Option<SchemaDefinition> {
+        self.inner.get_schema(uri).cloned()
+    }
+
+    fn get_class(&self, id: &str) -> PyResult<Option<ClassDefinition>> {
+        let conv = self.inner.converter();
+        Ok(self
+            .inner
+            .get_class_definition(&Identifier::new(id), &conv)
+            .map_err(|e| PyException::new_err(format!("{:?}", e)))?
+            .cloned())
+    }
 }
 
 /// A Python module implemented in Rust.
 #[cfg(feature = "python")]
-#[pymodule(name="schemaview")]
+#[pymodule(name = "schemaview")]
 pub fn schemaview_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     m.add_class::<PySchemaView>()?;
+    m.add_class::<SchemaDefinition>()?;
+    m.add_class::<ClassDefinition>()?;
     Ok(())
 }

--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::identifier::{converter_from_schema, Identifier, IdentifierError};
+use crate::identifier::{
+    converter_from_schema, converter_from_schemas, Identifier, IdentifierError,
+};
 use curies::Converter;
 use linkml_meta::{ClassDefinition, SchemaDefinition, SlotDefinition};
 
@@ -272,6 +274,22 @@ impl SchemaView {
             self.primary_schema = Some(schema_uri.to_string());
         }
         Ok(())
+    }
+
+    pub fn get_schema(&self, id: &str) -> Option<&SchemaDefinition> {
+        self.schema_definitions.get(id)
+    }
+
+    pub fn converter(&self) -> Converter {
+        converter_from_schemas(self.schema_definitions.values())
+    }
+
+    pub fn get_class_definition<'a>(
+        &'a self,
+        id: &Identifier,
+        conv: &Converter,
+    ) -> Result<Option<&'a ClassDefinition>, IdentifierError> {
+        Ok(self.get_class(id, conv)?.map(|cv| cv.class))
     }
 
     fn index_schema_classes(

--- a/src/schemaview/tests/python_api.rs
+++ b/src/schemaview/tests/python_api.rs
@@ -2,8 +2,8 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use std::path::PathBuf;
 use schemaview::schemaview_module;
+use std::path::PathBuf;
 
 fn meta_path() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -25,12 +25,51 @@ fn construct_via_python() {
         sys_modules.set_item("schemaview", module).unwrap();
 
         let locals = PyDict::new(py);
-        locals.set_item("meta_path", meta_path().to_str().unwrap()).unwrap();
-        pyo3::py_run!(py, *locals, r#"
+        locals
+            .set_item("meta_path", meta_path().to_str().unwrap())
+            .unwrap();
+        pyo3::py_run!(
+            py,
+            *locals,
+            r#"
 import schemaview
 sv = schemaview.SchemaView(meta_path)
 unresolved = sv.get_unresolved_schemas()
 assert "https://w3id.org/linkml/mappings" in unresolved
-"#);
+"#
+        );
+    });
+}
+
+#[test]
+fn definitions_via_python() {
+    pyo3::prepare_freethreaded_python();
+    let yaml = std::fs::read_to_string(meta_path()).unwrap();
+    Python::with_gil(|py| {
+        let module = PyModule::new(py, "schemaview").unwrap();
+        schemaview_module(&module).unwrap();
+        let sys = py.import("sys").unwrap();
+        let modules = sys.getattr("modules").unwrap();
+        let sys_modules = modules.downcast::<PyDict>().unwrap();
+        sys_modules.set_item("schemaview", module).unwrap();
+
+        let locals = PyDict::new(py);
+        locals.set_item("meta_yaml", &yaml).unwrap();
+        pyo3::py_run!(
+            py,
+            *locals,
+            r#"
+import schemaview
+sv = schemaview.SchemaView()
+sv.add_schema_str(meta_yaml)
+print('schemas', sv.get_unresolved_schemas())
+s = sv.get_schema('https://w3id.org/linkml/meta')
+print('schema', s)
+assert s is not None and s.name == 'meta'
+c = sv.get_class('linkml:class_definition')
+print('class', c)
+assert c is not None and c.name == 'class_definition'
+"#
+        );
     });
 }


### PR DESCRIPTION
## Summary
- extend `PySchemaView` to load schemas from strings or files
- expose retrieval of raw `SchemaDefinition` and `ClassDefinition`
- provide helper methods on `SchemaView`
- add test demonstrating new Python API

## Testing
- `cargo test --test python_api --features python -- --nocapture`
- `cargo test --all-features`

------
https://chatgpt.com/codex/tasks/task_e_685571ed9c848329935497f9a755ea9b