### PR TITLE
Add class option and validation to linkml-convert

### DIFF
--- a/src/runtime/src/bin/linkml_convert.rs
+++ b/src/runtime/src/bin/linkml_convert.rs
@@ -2,8 +2,10 @@ use clap::Parser;
 use linkml_runtime::{
     load_json_file, load_yaml_file,
     turtle::{write_turtle, TurtleOptions},
+    validate,
 };
 use schemaview::identifier::converter_from_schema;
+use schemaview::identifier::Identifier;
 use schemaview::io::from_yaml;
 use schemaview::schemaview::SchemaView;
 use std::fs::File;
@@ -15,6 +17,9 @@ struct Args {
     schema: PathBuf,
     /// Data file (YAML or JSON)
     data: PathBuf,
+    /// Name of the class to use as the root object
+    #[arg(short, long)]
+    class: Option<String>,
     /// Output TTL file
     #[arg(short, long)]
     output: PathBuf,
@@ -29,16 +34,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut sv = SchemaView::new();
     sv.add_schema(schema.clone()).map_err(|e| format!("{e}"))?;
     let conv = converter_from_schema(&schema);
+    let class_view = if let Some(cls_name) = &args.class {
+        Some(
+            sv.get_class(&Identifier::new(cls_name), &conv)
+                .map_err(|e| format!("{e:?}"))?
+                .ok_or("class not found")?,
+        )
+    } else {
+        None
+    };
     let data_path = &args.data;
     let value = if let Some(ext) = data_path.extension() {
         if ext == "json" {
-            load_json_file(data_path, &sv, None, &conv)?
+            load_json_file(data_path, &sv, class_view.as_ref(), &conv)?
         } else {
-            load_yaml_file(data_path, &sv, None, &conv)?
+            load_yaml_file(data_path, &sv, class_view.as_ref(), &conv)?
         }
     } else {
-        load_yaml_file(data_path, &sv, None, &conv)?
+        load_yaml_file(data_path, &sv, class_view.as_ref(), &conv)?
     };
+    if let Err(e) = validate(&value) {
+        eprintln!("invalid: {e}");
+        std::process::exit(1);
+    }
     let mut f = File::create(&args.output)?;
     write_turtle(
         &value,


### PR DESCRIPTION
## Summary
- add `--class` option to `linkml-convert`
- validate input before writing turtle output

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685576ac99f88329932da28203ae5890