### PR TITLE
Fix memory leak in LinkML runtime

### DIFF
--- a/src/runtime/src/turtle.rs
+++ b/src/runtime/src/turtle.rs
@@ -100,7 +100,7 @@ fn serialize_map<W: Write>(
                 formatter.format(&triple)?;
             }
             LinkMLValue::Map { values, class, .. } => {
-                let class = *class;
+                let class = class.as_ref();
                 let obj = state.next_subject();
                 let triple = Triple {
                     subject: subject.as_subject(),
@@ -126,7 +126,7 @@ fn serialize_map<W: Write>(
                         LinkMLValue::Map {
                             values: mv, class, ..
                         } => {
-                            let class = *class;
+                            let class = class.as_ref();
                             let obj = state.next_subject();
                             let triple = Triple {
                                 subject: subject.as_subject(),
@@ -179,7 +179,7 @@ pub fn write_turtle<W: Write>(
     let mut formatter = TurtleFormatter::new(w);
     match value {
         LinkMLValue::Map { values, class, .. } => {
-            let class = *class;
+            let class = class.as_ref();
             let subj = Node::Named(format!("{}root", state.base));
             serialize_map(&subj, values, class, &mut formatter, sv, conv, &mut state)?;
         }
@@ -190,7 +190,7 @@ pub fn write_turtle<W: Write>(
                     LinkMLValue::Map {
                         values: mv, class, ..
                     } => {
-                        let class = *class;
+                        let class = class.as_ref();
                         serialize_map(&subj, mv, class, &mut formatter, sv, conv, &mut state)?;
                     }
                     LinkMLValue::Scalar { value, .. } => {


### PR DESCRIPTION
## Summary
- remove `Box::leak` usage in runtime and own `ClassView`/`SlotView`
- adjust turtle serializer for owned class data

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685902e91e8c8329a2a74379774ceb66