### PR TITLE
Propagate IO errors from turtle_to_string

### DIFF
--- a/src/runtime/src/turtle.rs
+++ b/src/runtime/src/turtle.rs
@@ -220,8 +220,8 @@ pub fn turtle_to_string(
     schema: &SchemaDefinition,
     conv: &Converter,
     options: TurtleOptions,
-) -> String {
+) -> Result<String, std::io::Error> {
     let mut buf = Vec::new();
-    write_turtle(value, sv, schema, conv, &mut buf, options).unwrap();
-    String::from_utf8(buf).unwrap()
+    write_turtle(value, sv, schema, conv, &mut buf, options)?;
+    String::from_utf8(buf).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
 }

--- a/src/runtime/tests/convert.rs
+++ b/src/runtime/tests/convert.rs
@@ -22,7 +22,7 @@ fn convert_person_to_ttl() {
     sv.add_schema(schema.clone()).unwrap();
     let conv = converter_from_schema(&schema);
     let v = load_yaml_file(Path::new(&data_path("person_valid.yaml")), &sv, None, &conv).unwrap();
-    let ttl = turtle_to_string(&v, &sv, &schema, &conv, TurtleOptions { skolem: false });
+    let ttl = turtle_to_string(&v, &sv, &schema, &conv, TurtleOptions { skolem: false }).unwrap();
     assert!(ttl.contains("@prefix test: <https://example.com/test/> ."));
     assert!(ttl.contains("<test:name> \"Alice\""));
 }


### PR DESCRIPTION
## Summary
- propagate errors from `write_turtle` and `String::from_utf8`
- update tests for the new `turtle_to_string` return type

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68590a11fa4c8329a11a38cce884df52