### PR TITLE
Add Python feature to runtime crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "curies",
  "linkml_meta",
  "predicates 2.1.5",
+ "pyo3",
  "rio_api",
  "rio_turtle",
  "schemaview",

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [lib]
 name = "linkml_runtime"
+crate-type = ["rlib", "cdylib"]
 
 [[bin]]
 name = "linkml-validate"
@@ -23,8 +24,12 @@ curies = "0.1.3"
 linkml_meta = { path = "../metamodel" }
 rio_turtle = "0.8"
 rio_api = "0.8"
+pyo3 = { version = "0.25.0", features = ["extension-module"], optional = true }
 
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "2"
 tempfile = "3"
+
+[features]
+python = ["pyo3", "linkml_schemaview/python", "linkml_meta/pyo3"]

--- a/src/schemaview/src/lib.rs
+++ b/src/schemaview/src/lib.rs
@@ -60,7 +60,7 @@ pub struct PySlotView {
 impl PySchemaView {
     #[new]
     #[pyo3(signature = (path=None))]
-    fn new(path: Option<&str>) -> PyResult<Self> {
+    pub fn new(path: Option<&str>) -> PyResult<Self> {
         let mut sv = RustSchemaView::new();
         if let Some(p) = path {
             let schema = crate::io::from_yaml(Path::new(p))


### PR DESCRIPTION
## Summary
- enable optional python support in `linkml_runtime`
- expose `PySchemaView::new` for external use
- export Python bindings from runtime crate

## Testing
- `cargo test --quiet`
- `cargo build --quiet --features python -p linkml_runtime`


------
https://chatgpt.com/codex/tasks/task_e_685946d3278883298da5e8c0f875a20f