### PR TITLE
Expose LinkMLValue to Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
 name = "linkml-core"
 version = "0.1.0"
 dependencies = [
+ "linkml_runtime",
  "pyo3",
 ]
 

--- a/src/main/Cargo.toml
+++ b/src/main/Cargo.toml
@@ -5,8 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-name = "linkml_runtime"
+name = "linkml_runtime_py"
 crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.25.0"
+runtime = { package = "linkml_runtime", path = "../runtime", features = ["python"] }

--- a/src/main/src/lib.rs
+++ b/src/main/src/lib.rs
@@ -1,15 +1,7 @@
 use pyo3::prelude::*;
+use runtime::runtime_module as inner_module;
 
-
-/// Formats the sum of two numbers as string.
-#[pyfunction]
-fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
-    Ok((a + b).to_string())
-}
-
-/// A Python module implemented in Rust.
 #[pymodule(name = "linkml_runtime")]
 fn linkml_runtime(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
-    Ok(())
+    inner_module(m)
 }

--- a/src/runtime/tests/python_value.rs
+++ b/src/runtime/tests/python_value.rs
@@ -1,0 +1,53 @@
+#![cfg(feature = "python")]
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use linkml_runtime::runtime_module;
+use std::path::PathBuf;
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn load_value_via_python() {
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let module = PyModule::new(py, "linkml_runtime").unwrap();
+        runtime_module(&module).unwrap();
+        let sys = py.import("sys").unwrap();
+        let modules = sys.getattr("modules").unwrap();
+        let sys_modules = modules.downcast::<PyDict>().unwrap();
+        sys_modules.set_item("linkml_runtime", module).unwrap();
+
+        let locals = PyDict::new(py);
+        locals
+            .set_item("schema_path", data_path("schema.yaml").to_str().unwrap())
+            .unwrap();
+        locals
+            .set_item(
+                "person_path",
+                data_path("person_valid.yaml").to_str().unwrap(),
+            )
+            .unwrap();
+
+        pyo3::py_run!(
+            py,
+            *locals,
+            r#"
+import linkml_runtime as lr
+sv = lr.make_schema_view(schema_path)
+cls = sv.get_class_view('Person')
+value = lr.load_yaml(person_path, sv, cls)
+assert value.class_name() == 'Person'
+assert value['name'].slot_name() == 'name'
+assert value['name'].as_python() == 'Alice'
+"#
+        );
+    });
+}
+

--- a/src/schemaview/src/lib.rs
+++ b/src/schemaview/src/lib.rs
@@ -41,6 +41,12 @@ pub struct PySchemaView {
     inner: RustSchemaView,
 }
 
+impl PySchemaView {
+    pub fn as_rust(&self) -> &RustSchemaView {
+        &self.inner
+    }
+}
+
 #[cfg(feature = "python")]
 #[pyclass(name = "ClassView")]
 pub struct PyClassView {
@@ -145,7 +151,7 @@ impl PySchemaView {
 #[pymethods]
 impl PyClassView {
     #[getter]
-    fn name(&self) -> String {
+    pub fn name(&self) -> String {
         self.class_name.clone()
     }
 
@@ -174,7 +180,7 @@ impl PyClassView {
 #[pymethods]
 impl PySlotView {
     #[getter]
-    fn name(&self) -> String {
+    pub fn name(&self) -> String {
         self.slot_name.clone()
     }
 }


### PR DESCRIPTION
## Summary
- expose LinkMLValue to Python with `class_name` and `slot_name`
- add helper conversion to Python objects
- re-export runtime module from python wrapper
- add Python test showing meta access using py_run

## Testing
- `cargo check --all --features python`
- `maturin develop --manifest-path src/main/Cargo.toml -q` *(fails: Couldn't find a virtualenv)*

------
https://chatgpt.com/codex/tasks/task_e_685949de99648329b715070c15977da1