### PR TITLE
Refactor diff and patch utilities

### DIFF
--- a/src/runtime/src/diff.rs
+++ b/src/runtime/src/diff.rs
@@ -1,0 +1,110 @@
+use crate::{load_json_str, LinkMLValue};
+use linkml_schemaview::schemaview::SchemaView;
+use serde_json::{Value as JsonValue, Map};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Delta {
+    pub path: Vec<String>,
+    pub old: Option<JsonValue>,
+    pub new: Option<JsonValue>,
+}
+
+impl<'a> LinkMLValue<'a> {
+    pub fn to_json(&self) -> JsonValue {
+        match self {
+            LinkMLValue::Scalar { value, .. } => value.clone(),
+            LinkMLValue::List { values, .. } => {
+                JsonValue::Array(values.iter().map(|v| v.to_json()).collect())
+            }
+            LinkMLValue::Map { values, .. } => JsonValue::Object(
+                values
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.to_json()))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+pub fn diff<'a>(source: &LinkMLValue<'a>, target: &LinkMLValue<'a>, ignore_missing_target: bool) -> Vec<Delta> {
+    fn inner<'b>(path: &mut Vec<String>, s: &LinkMLValue<'b>, t: &LinkMLValue<'b>, ignore_missing: bool, out: &mut Vec<Delta>) {
+        match (s, t) {
+            (LinkMLValue::Map { values: sm, .. }, LinkMLValue::Map { values: tm, .. }) => {
+                for (k, sv) in sm {
+                    path.push(k.clone());
+                    match tm.get(k) {
+                        Some(tv) => inner(path, sv, tv, ignore_missing, out),
+                        None => {
+                            if !ignore_missing {
+                                out.push(Delta { path: path.clone(), old: Some(sv.to_json()), new: None });
+                            }
+                        }
+                    }
+                    path.pop();
+                }
+                for (k, tv) in tm {
+                    if !sm.contains_key(k) {
+                        path.push(k.clone());
+                        out.push(Delta { path: path.clone(), old: None, new: Some(tv.to_json()) });
+                        path.pop();
+                    }
+                }
+            }
+            _ => {
+                let sv = s.to_json();
+                let tv = t.to_json();
+                if sv != tv {
+                    out.push(Delta { path: path.clone(), old: Some(sv), new: Some(tv) });
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    inner(&mut Vec::new(), source, target, ignore_missing_target, &mut out);
+    out
+}
+
+pub fn patch<'a>(source: &'a LinkMLValue<'a>, deltas: &[Delta], sv: &'a SchemaView) -> LinkMLValue<'a> {
+    let mut json = source.to_json();
+    for d in deltas {
+        apply_delta(&mut json, d);
+    }
+    let json_str = serde_json::to_string(&json).unwrap();
+    let conv = sv.converter();
+    match source {
+        LinkMLValue::Map { class: Some(ref c), .. } => {
+            load_json_str(&json_str, sv, Some(c), &conv).unwrap()
+        }
+        _ => load_json_str(&json_str, sv, None, &conv).unwrap(),
+    }
+}
+
+fn apply_delta(value: &mut JsonValue, delta: &Delta) {
+    apply_delta_inner(value, &delta.path, &delta.new);
+}
+
+fn apply_delta_inner(value: &mut JsonValue, path: &[String], newv: &Option<JsonValue>) {
+    if path.is_empty() {
+        if let Some(v) = newv { *value = v.clone(); }
+        return;
+    }
+    match value {
+        JsonValue::Object(map) => {
+            let key = &path[0];
+            if path.len() == 1 {
+                match newv {
+                    Some(v) => { map.insert(key.clone(), v.clone()); },
+                    None => { map.remove(key); },
+                }
+            } else {
+                let entry = map.entry(key.clone()).or_insert(JsonValue::Object(Map::new()));
+                apply_delta_inner(entry, &path[1..], newv);
+            }
+        }
+        _ => {
+            if path.is_empty() {
+                if let Some(v) = newv { *value = v.clone(); }
+            }
+        }
+    }
+}

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -8,7 +8,9 @@ use std::path::Path;
 
 #[cfg(feature = "python")]
 pub mod python;
+pub mod diff;
 pub mod turtle;
+pub use diff::{Delta, diff, patch};
 #[cfg(feature = "python")]
 pub use python::*;
 pub enum LinkMLValue<'a> {

--- a/src/runtime/src/python.rs
+++ b/src/runtime/src/python.rs
@@ -262,11 +262,7 @@ impl LinkMLValueOwned {
     }
 
     fn to_linkml<'a>(&self, sv: &'a SchemaView) -> LinkMLValue<'a> {
-        fn inner<'a>(
-            v: &LinkMLValueOwned,
-            sv: &'a SchemaView,
-            conv: &Converter,
-        ) -> LinkMLValue<'a> {
+        fn inner<'a>(v: &LinkMLValueOwned, sv: &'a SchemaView, conv: &Converter) -> LinkMLValue<'a> {
             match v {
                 LinkMLValueOwned::Scalar { value, slot } => {
                     let slot_view = slot
@@ -307,6 +303,7 @@ impl LinkMLValueOwned {
         inner(self, sv, &conv)
     }
 }
+
 
 #[pyclass(name = "LinkMLValue")]
 pub struct PyLinkMLValue {

--- a/src/runtime/tests/data/person_older.yaml
+++ b/src/runtime/tests/data/person_older.yaml
@@ -1,0 +1,2 @@
+name: Alice
+age: 40

--- a/src/runtime/tests/data/person_partial.yaml
+++ b/src/runtime/tests/data/person_partial.yaml
@@ -1,0 +1,1 @@
+name: Alice

--- a/src/runtime/tests/diff.rs
+++ b/src/runtime/tests/diff.rs
@@ -1,0 +1,56 @@
+use linkml_runtime::{load_yaml_file, diff, patch};
+use linkml_schemaview::identifier::{converter_from_schema, Identifier};
+use linkml_schemaview::io::from_yaml;
+use linkml_schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn diff_and_patch_person() {
+    let schema = from_yaml(Path::new(&data_path("schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Person"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let src = load_yaml_file(Path::new(&data_path("person_valid.yaml")), &sv, Some(&class), &conv).unwrap();
+    let tgt = load_yaml_file(Path::new(&data_path("person_older.yaml")), &sv, Some(&class), &conv).unwrap();
+
+    let deltas = diff(&src, &tgt, false);
+    assert_eq!(deltas.len(), 1);
+
+    let patched = patch(&src, &deltas, &sv);
+    let patched_json = patched.to_json();
+    let target_json = tgt.to_json();
+    assert_eq!(patched_json, target_json);
+}
+
+#[test]
+fn diff_ignore_missing_target() {
+    let schema = from_yaml(Path::new(&data_path("schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Person"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let src = load_yaml_file(Path::new(&data_path("person_valid.yaml")), &sv, Some(&class), &conv).unwrap();
+    let tgt = load_yaml_file(Path::new(&data_path("person_partial.yaml")), &sv, Some(&class), &conv).unwrap();
+
+    let deltas = diff(&src, &tgt, true);
+    assert!(deltas.is_empty());
+    let patched = patch(&src, &deltas, &sv);
+    let patched_json = patched.to_json();
+    let src_json = src.to_json();
+    assert_eq!(patched_json, src_json);
+}


### PR DESCRIPTION
## Summary
- reimplement diff/patch storing plain JSON values in `Delta`
- expose `to_json` helper on `LinkMLValue`
- adjust Python bindings to keep internal `LinkMLValueOwned`
- update tests for new API

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685a631c30308329bd8ddbd003c56a01