### PR TITLE
Implement diff ignore annotation

### DIFF
--- a/src/runtime/src/diff.rs
+++ b/src/runtime/src/diff.rs
@@ -1,6 +1,14 @@
 use crate::{load_json_str, LinkMLValue};
-use linkml_schemaview::schemaview::SchemaView;
-use serde_json::{Value as JsonValue, Map};
+use linkml_schemaview::schemaview::{SchemaView, SlotView};
+use serde_json::{Map, Value as JsonValue};
+
+const IGNORE_ANNOTATION: &str = "diff.linkml.io/ignore";
+
+fn slot_is_ignored(slot: &SlotView) -> bool {
+    slot.merged_definition()
+        .annotations
+        .contains_key(IGNORE_ANNOTATION)
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Delta {
@@ -26,17 +34,55 @@ impl<'a> LinkMLValue<'a> {
     }
 }
 
-pub fn diff<'a>(source: &LinkMLValue<'a>, target: &LinkMLValue<'a>, ignore_missing_target: bool) -> Vec<Delta> {
-    fn inner<'b>(path: &mut Vec<String>, s: &LinkMLValue<'b>, t: &LinkMLValue<'b>, ignore_missing: bool, out: &mut Vec<Delta>) {
+pub fn diff<'a>(
+    source: &LinkMLValue<'a>,
+    target: &LinkMLValue<'a>,
+    ignore_missing_target: bool,
+) -> Vec<Delta> {
+    fn inner<'b>(
+        path: &mut Vec<String>,
+        slot: Option<&SlotView<'b>>,
+        s: &LinkMLValue<'b>,
+        t: &LinkMLValue<'b>,
+        ignore_missing: bool,
+        out: &mut Vec<Delta>,
+    ) {
+        if let Some(sl) = slot {
+            if slot_is_ignored(sl) {
+                return;
+            }
+        }
         match (s, t) {
-            (LinkMLValue::Map { values: sm, .. }, LinkMLValue::Map { values: tm, .. }) => {
+            (
+                LinkMLValue::Map {
+                    values: sm,
+                    class: sc,
+                    ..
+                },
+                LinkMLValue::Map {
+                    values: tm,
+                    class: tc,
+                    ..
+                },
+            ) => {
                 for (k, sv) in sm {
+                    let slot_view = sc
+                        .as_ref()
+                        .and_then(|cv| cv.slots().iter().find(|s| s.name == *k))
+                        .or_else(|| {
+                            tc.as_ref()
+                                .and_then(|cv| cv.slots().iter().find(|s| s.name == *k))
+                        });
                     path.push(k.clone());
                     match tm.get(k) {
-                        Some(tv) => inner(path, sv, tv, ignore_missing, out),
+                        Some(tv) => inner(path, slot_view, sv, tv, ignore_missing, out),
                         None => {
-                            if !ignore_missing {
-                                out.push(Delta { path: path.clone(), old: Some(sv.to_json()), new: None });
+                            if !ignore_missing && !slot_view.map_or(false, slot_is_ignored) {
+                                out.push(Delta {
+                                    path: path.clone(),
+                                    old: Some(sv.to_json()),
+                                    new: None,
+                                });
                             }
                         }
                     }
@@ -44,9 +90,22 @@ pub fn diff<'a>(source: &LinkMLValue<'a>, target: &LinkMLValue<'a>, ignore_missi
                 }
                 for (k, tv) in tm {
                     if !sm.contains_key(k) {
-                        path.push(k.clone());
-                        out.push(Delta { path: path.clone(), old: None, new: Some(tv.to_json()) });
-                        path.pop();
+                        let slot_view = sc
+                            .as_ref()
+                            .and_then(|cv| cv.slots().iter().find(|s| s.name == *k))
+                            .or_else(|| {
+                                tc.as_ref()
+                                    .and_then(|cv| cv.slots().iter().find(|s| s.name == *k))
+                            });
+                        if !slot_view.map_or(false, slot_is_ignored) {
+                            path.push(k.clone());
+                            out.push(Delta {
+                                path: path.clone(),
+                                old: None,
+                                new: Some(tv.to_json()),
+                            });
+                            path.pop();
+                        }
                     }
                 }
             }
@@ -54,17 +113,32 @@ pub fn diff<'a>(source: &LinkMLValue<'a>, target: &LinkMLValue<'a>, ignore_missi
                 let sv = s.to_json();
                 let tv = t.to_json();
                 if sv != tv {
-                    out.push(Delta { path: path.clone(), old: Some(sv), new: Some(tv) });
+                    out.push(Delta {
+                        path: path.clone(),
+                        old: Some(sv),
+                        new: Some(tv),
+                    });
                 }
             }
         }
     }
     let mut out = Vec::new();
-    inner(&mut Vec::new(), source, target, ignore_missing_target, &mut out);
+    inner(
+        &mut Vec::new(),
+        None,
+        source,
+        target,
+        ignore_missing_target,
+        &mut out,
+    );
     out
 }
 
-pub fn patch<'a>(source: &'a LinkMLValue<'a>, deltas: &[Delta], sv: &'a SchemaView) -> LinkMLValue<'a> {
+pub fn patch<'a>(
+    source: &'a LinkMLValue<'a>,
+    deltas: &[Delta],
+    sv: &'a SchemaView,
+) -> LinkMLValue<'a> {
     let mut json = source.to_json();
     for d in deltas {
         apply_delta(&mut json, d);
@@ -72,9 +146,9 @@ pub fn patch<'a>(source: &'a LinkMLValue<'a>, deltas: &[Delta], sv: &'a SchemaVi
     let json_str = serde_json::to_string(&json).unwrap();
     let conv = sv.converter();
     match source {
-        LinkMLValue::Map { class: Some(ref c), .. } => {
-            load_json_str(&json_str, sv, Some(c), &conv).unwrap()
-        }
+        LinkMLValue::Map {
+            class: Some(ref c), ..
+        } => load_json_str(&json_str, sv, Some(c), &conv).unwrap(),
         _ => load_json_str(&json_str, sv, None, &conv).unwrap(),
     }
 }
@@ -85,7 +159,9 @@ fn apply_delta(value: &mut JsonValue, delta: &Delta) {
 
 fn apply_delta_inner(value: &mut JsonValue, path: &[String], newv: &Option<JsonValue>) {
     if path.is_empty() {
-        if let Some(v) = newv { *value = v.clone(); }
+        if let Some(v) = newv {
+            *value = v.clone();
+        }
         return;
     }
     match value {
@@ -93,17 +169,25 @@ fn apply_delta_inner(value: &mut JsonValue, path: &[String], newv: &Option<JsonV
             let key = &path[0];
             if path.len() == 1 {
                 match newv {
-                    Some(v) => { map.insert(key.clone(), v.clone()); },
-                    None => { map.remove(key); },
+                    Some(v) => {
+                        map.insert(key.clone(), v.clone());
+                    }
+                    None => {
+                        map.remove(key);
+                    }
                 }
             } else {
-                let entry = map.entry(key.clone()).or_insert(JsonValue::Object(Map::new()));
+                let entry = map
+                    .entry(key.clone())
+                    .or_insert(JsonValue::Object(Map::new()));
                 apply_delta_inner(entry, &path[1..], newv);
             }
         }
         _ => {
             if path.is_empty() {
-                if let Some(v) = newv { *value = v.clone(); }
+                if let Some(v) = newv {
+                    *value = v.clone();
+                }
             }
         }
     }

--- a/src/runtime/tests/data/person_invalid.yaml
+++ b/src/runtime/tests/data/person_invalid.yaml
@@ -1,3 +1,4 @@
 name: Bob
 age: 25
 extra: foo
+internal_id: idi

--- a/src/runtime/tests/data/person_older.yaml
+++ b/src/runtime/tests/data/person_older.yaml
@@ -1,2 +1,3 @@
 name: Alice
 age: 40
+internal_id: id2

--- a/src/runtime/tests/data/person_partial.yaml
+++ b/src/runtime/tests/data/person_partial.yaml
@@ -1,1 +1,2 @@
 name: Alice
+internal_id: idp

--- a/src/runtime/tests/data/person_valid.yaml
+++ b/src/runtime/tests/data/person_valid.yaml
@@ -1,2 +1,3 @@
 name: Alice
 age: 33
+internal_id: id1

--- a/src/runtime/tests/data/schema.yaml
+++ b/src/runtime/tests/data/schema.yaml
@@ -8,3 +8,7 @@ classes:
     attributes:
       name:
       age:
+      internal_id:
+        annotations:
+          diff.linkml.io/ignore:
+            extension_value: {}

--- a/src/runtime/tests/diff.rs
+++ b/src/runtime/tests/diff.rs
@@ -1,4 +1,4 @@
-use linkml_runtime::{load_yaml_file, diff, patch};
+use linkml_runtime::{diff, load_yaml_file, patch};
 use linkml_schemaview::identifier::{converter_from_schema, Identifier};
 use linkml_schemaview::io::from_yaml;
 use linkml_schemaview::schemaview::SchemaView;
@@ -22,8 +22,20 @@ fn diff_and_patch_person() {
         .get_class(&Identifier::new("Person"), &conv)
         .unwrap()
         .expect("class not found");
-    let src = load_yaml_file(Path::new(&data_path("person_valid.yaml")), &sv, Some(&class), &conv).unwrap();
-    let tgt = load_yaml_file(Path::new(&data_path("person_older.yaml")), &sv, Some(&class), &conv).unwrap();
+    let src = load_yaml_file(
+        Path::new(&data_path("person_valid.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
+    let tgt = load_yaml_file(
+        Path::new(&data_path("person_older.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
 
     let deltas = diff(&src, &tgt, false);
     assert_eq!(deltas.len(), 1);
@@ -31,7 +43,10 @@ fn diff_and_patch_person() {
     let patched = patch(&src, &deltas, &sv);
     let patched_json = patched.to_json();
     let target_json = tgt.to_json();
-    assert_eq!(patched_json, target_json);
+    let src_json = src.to_json();
+    assert_ne!(patched_json, target_json);
+    assert_eq!(patched_json.get("age"), target_json.get("age"));
+    assert_eq!(patched_json.get("internal_id"), src_json.get("internal_id"));
 }
 
 #[test]
@@ -44,8 +59,20 @@ fn diff_ignore_missing_target() {
         .get_class(&Identifier::new("Person"), &conv)
         .unwrap()
         .expect("class not found");
-    let src = load_yaml_file(Path::new(&data_path("person_valid.yaml")), &sv, Some(&class), &conv).unwrap();
-    let tgt = load_yaml_file(Path::new(&data_path("person_partial.yaml")), &sv, Some(&class), &conv).unwrap();
+    let src = load_yaml_file(
+        Path::new(&data_path("person_valid.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
+    let tgt = load_yaml_file(
+        Path::new(&data_path("person_partial.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
 
     let deltas = diff(&src, &tgt, true);
     assert!(deltas.is_empty());


### PR DESCRIPTION
## Summary
- support diff ignore annotation `diff.linkml.io/ignore`
- add `internal_id` field with the ignore annotation in test schema
- update test data and expectations

## Testing
- `cargo test -p linkml_runtime --test diff -- --nocapture`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685acad726188329a31790fe939f31cc