### PR TITLE
Add personinfo diff tests and invalid example

### DIFF
--- a/src/runtime/tests/example_personinfo_data_invalid.yaml
+++ b/src/runtime/tests/example_personinfo_data_invalid.yaml
@@ -1,0 +1,11 @@
+objects:
+  - id: T
+    type: https://w3id.org/linkml/examples/personinfo/Organization
+    name: club
+    unknown_attr: should_fail
+  - id: P:001
+    name: fred bloggs
+    type: https://w3id.org/linkml/examples/personinfo/Person
+    primary_email: fred.bloggs@example.com
+    age_in_years: 33
+    favorite_color: blue


### PR DESCRIPTION
## Summary
- add `info_path` helper for personinfo resources
- create diff & patch test using new personinfo schema and data
- create invalid personinfo data example
- test that invalid personinfo data fails validation

## Testing
- `cargo test diff_and_patch_personinfo -- --nocapture`
- `cargo test personinfo_invalid_fails -- --nocapture`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685bb49f24ec8329a8650e5599ac9646