### PR TITLE
Handle local file imports

### DIFF
--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -136,7 +136,14 @@ impl SchemaView {
                             unresolved.push(uri);
                         }
                     }
-                    None => {}
+                    None => {
+                        // if the import cannot be expanded to a URI, treat it as a
+                        // potential local file path and attempt to resolve later
+                        let path = import.to_string();
+                        if !self.schema_definitions.contains_key(&path) {
+                            unresolved.push(path);
+                        }
+                    }
                 }
             }
         }

--- a/src/schemaview/tests/data/local_main.yaml
+++ b/src/schemaview/tests/data/local_main.yaml
@@ -1,0 +1,15 @@
+id: http://example.com/local_main
+name: local_main
+prefixes:
+  local_main: http://example.com/local_main/
+  local_target: http://example.com/local_target/
+default_prefix: local_main
+imports:
+  - tests/data/local_target.yaml
+classes:
+  MainThing:
+    attributes:
+      id:
+        identifier: true
+      target:
+        range: local_target:TargetThing

--- a/src/schemaview/tests/data/local_target.yaml
+++ b/src/schemaview/tests/data/local_target.yaml
@@ -1,0 +1,10 @@
+id: http://example.com/local_target
+name: local_target
+prefixes:
+  local_target: http://example.com/local_target/
+default_prefix: local_target
+classes:
+  TargetThing:
+    attributes:
+      id:
+        identifier: true

--- a/src/schemaview/tests/local_import.rs
+++ b/src/schemaview/tests/local_import.rs
@@ -1,0 +1,25 @@
+use linkml_schemaview::io::from_yaml;
+use linkml_schemaview::schemaview::SchemaView;
+use linkml_schemaview::resolve::resolve_schemas;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn resolve_local_import() {
+    let schema = from_yaml(Path::new(&data_path("local_main.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema).unwrap();
+    let unresolved = sv.get_unresolved_schemas();
+    assert!(unresolved.contains(&"tests/data/local_target.yaml".to_string()));
+    resolve_schemas(&mut sv).unwrap();
+    let unresolved = sv.get_unresolved_schemas();
+    assert!(unresolved.is_empty());
+    assert!(sv.get_schema("http://example.com/local_target").is_some());
+}


### PR DESCRIPTION
## Summary
- treat unresolved imports that look like file paths as local schema files
- resolve local file imports
- test resolving a local import

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685bf9f1b5f88329944927424739f315