### PR TITLE
Add is_a and slot existence checks to schema validation

### DIFF
--- a/src/runtime/src/bin/linkml_schema_validate.rs
+++ b/src/runtime/src/bin/linkml_schema_validate.rs
@@ -77,6 +77,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
+
+        for (class_name, class_def) in &schema_def.classes {
+            if let Some(parent) = &class_def.is_a {
+                let id = Identifier::new(parent);
+                if sv
+                    .get_class(&id, &conv)
+                    .map_err(|e| format!("{e:?}"))?
+                    .is_none()
+                {
+                    errors.push(format!(
+                        "Unknown parent class `{}` referenced by class `{}` in schema `{}`",
+                        parent, class_name, schema_uri
+                    ));
+                }
+            }
+            for slot in &class_def.slots {
+                let id = Identifier::new(slot);
+                if sv
+                    .get_slot(&id, &conv)
+                    .map_err(|e| format!("{e:?}"))?
+                    .is_none()
+                {
+                    errors.push(format!(
+                        "Unknown slot `{}` used in class `{}` in schema `{}`",
+                        slot, class_name, schema_uri
+                    ));
+                }
+            }
+        }
     }
 
     if errors.is_empty() {

--- a/src/runtime/tests/data/invalid_schema.yaml
+++ b/src/runtime/tests/data/invalid_schema.yaml
@@ -1,0 +1,13 @@
+id: https://example.com/invalid
+name: invalid
+prefixes:
+  ex: https://example.com/
+default_prefix: ex
+classes:
+  A:
+    is_a: B
+    slots:
+      - unknown_slot
+slots:
+  name:
+    range: string

--- a/src/runtime/tests/schema_validate.rs
+++ b/src/runtime/tests/schema_validate.rs
@@ -1,0 +1,22 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::PathBuf;
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn detect_invalid_schema() {
+    let schema = data_path("invalid_schema.yaml");
+    let mut cmd = Command::cargo_bin("linkml-schema-validate").unwrap();
+    cmd.arg(&schema);
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("Unknown parent class"))
+        .stdout(predicate::str::contains("Unknown slot"));
+}


### PR DESCRIPTION
## Summary
- detect broken `is_a` references when validating schemas
- check that slots mentioned in class definitions actually exist
- add tests for schema validator CLI

## Testing
- `cargo test --quiet`
- `cargo test -p linkml_runtime detect_invalid_schema -- --exact --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685bfea5c34c8329b9977d41fb5428b8