### PR TITLE
Add cross schema class resolution test

### DIFF
--- a/src/schemaview/src/classview.rs
+++ b/src/schemaview/src/classview.rs
@@ -226,6 +226,17 @@ impl<'a> ClassView<'a> {
         Ok(out)
     }
 
+    pub fn parent_class(&self) -> Result<Option<ClassView<'a>>, IdentifierError> {
+        let conv = match self.sv.converter_for_schema(self.schema_uri) {
+            Some(c) => c,
+            None => return Ok(None),
+        };
+        match &self.class.is_a {
+            Some(parent) => self.sv.get_class(&Identifier::new(parent), &conv),
+            None => Ok(None),
+        }
+    }
+
     pub fn key_or_identifier_slot(&'a self) -> Option<&'a SlotView<'a>> {
         self.slots.iter().find(|s| {
             let d = s.merged_definition();

--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -56,6 +56,12 @@ impl SchemaView {
         converter_from_schemas(self.schema_definitions.values())
     }
 
+    pub fn converter_for_schema(&self, schema_uri: &str) -> Option<Converter> {
+        self.schema_definitions
+            .get(schema_uri)
+            .map(|s| converter_from_schema(s))
+    }
+
     pub fn get_class_definition<'a>(
         &'a self,
         id: &Identifier,

--- a/src/schemaview/tests/cross_schema_is_a.rs
+++ b/src/schemaview/tests/cross_schema_is_a.rs
@@ -1,0 +1,59 @@
+use linkml_schemaview::identifier::{converter_from_schemas, Identifier};
+use linkml_schemaview::io::from_yaml;
+use linkml_schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn cross_schema_is_a() {
+    let geo_schema = from_yaml(Path::new(&data_path("geo.yaml"))).unwrap();
+    let era_schema = from_yaml(Path::new(&data_path("era.yaml"))).unwrap();
+
+    let mut sv = SchemaView::new();
+    sv.add_schema(geo_schema.clone()).unwrap();
+    sv.add_schema(era_schema.clone()).unwrap();
+
+    let conv = converter_from_schemas([&geo_schema, &era_schema]);
+
+    let era_geom_curie = sv
+        .get_class(&Identifier::new("era:Geometry"), &conv)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        era_geom_curie
+            .get_uri(&conv, false, false)
+            .unwrap()
+            .to_string(),
+        "era:Geometry"
+    );
+
+    let parent = era_geom_curie.parent_class().unwrap().unwrap();
+    assert_eq!(
+        parent
+            .get_uri(&conv, false, false)
+            .unwrap()
+            .to_string(),
+        "geo:Geometry"
+    );
+
+    let era_geom_uri = sv
+        .get_class(&Identifier::new("http://example.com/era/Geometry"), &conv)
+        .unwrap()
+        .unwrap();
+    let parent_uri = era_geom_uri.parent_class().unwrap().unwrap();
+    assert_eq!(
+        parent_uri
+            .get_uri(&conv, false, false)
+            .unwrap()
+            .to_string(),
+        "geo:Geometry"
+    );
+}
+

--- a/src/schemaview/tests/data/era.yaml
+++ b/src/schemaview/tests/data/era.yaml
@@ -1,0 +1,14 @@
+id: http://example.com/era
+name: era
+prefixes:
+  era: http://example.com/era/
+  geo: http://example.com/geo/
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+  - http://example.com/geo
+default_prefix: era
+classes:
+  Geometry:
+    is_a: geo:Geometry
+    description: Extended geometry

--- a/src/schemaview/tests/data/geo.yaml
+++ b/src/schemaview/tests/data/geo.yaml
@@ -1,0 +1,11 @@
+id: http://example.com/geo
+name: geo
+prefixes:
+  geo: http://example.com/geo/
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_prefix: geo
+classes:
+  Geometry:
+    description: Base geometry class


### PR DESCRIPTION
## Summary
- add minimal `geo` and `era` example schemas
- test `SchemaView` cross-schema `is_a` resolution using new `ClassView::parent_class`
- remove `Converter` argument from `ClassView::parent_class` and use `SchemaView`'s converter
- use schema-specific converter for parent lookup

## Testing
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685d16bd96608329929cd1c16432a2ec