### PR TITLE
Support CURIE-like names in index functions

### DIFF
--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -77,7 +77,12 @@ impl SchemaView {
     ) -> Result<(), IdentifierError> {
         let default_prefix = schema.default_prefix.as_deref().unwrap_or(&schema.name);
         for (class_name, class_def) in &schema.classes {
-            let default_uri = Identifier::new(&format!("{}:{}", default_prefix, class_name))
+            let default_id = if class_name.contains(':') && class_def.class_uri.is_none() {
+                Identifier::new(class_name)
+            } else {
+                Identifier::new(&format!("{}:{}", default_prefix, class_name))
+            };
+            let default_uri = default_id
                 .to_uri(conv)
                 .map(|u| u.0)
                 .unwrap_or_else(|_| format!("{}/{}", schema.id.trim_end_matches('/'), class_name));
@@ -109,7 +114,12 @@ impl SchemaView {
     ) -> Result<(), IdentifierError> {
         let default_prefix = schema.default_prefix.as_deref().unwrap_or(&schema.name);
         for (slot_name, slot_def) in &schema.slot_definitions {
-            let default_uri = Identifier::new(&format!("{}:{}", default_prefix, slot_name))
+            let default_id = if slot_name.contains(':') && slot_def.slot_uri.is_none() {
+                Identifier::new(slot_name)
+            } else {
+                Identifier::new(&format!("{}:{}", default_prefix, slot_name))
+            };
+            let default_uri = default_id
                 .to_uri(conv)
                 .map(|u| u.0)
                 .unwrap_or_else(|_| format!("{}/{}", schema.id.trim_end_matches('/'), slot_name));

--- a/src/schemaview/tests/data/prefixed_names.yaml
+++ b/src/schemaview/tests/data/prefixed_names.yaml
@@ -1,0 +1,17 @@
+id: http://example.com/prefixed
+name: prefixed
+prefixes:
+  pref: http://example.com/prefixed/
+  geo: http://example.com/geo/
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_prefix: pref
+slots:
+  "geo:point":
+    range: string
+classes:
+  "geo:Geometry":
+    description: Geometry class with prefixed name
+    slots:
+      - "geo:point"

--- a/src/schemaview/tests/prefixed_names.rs
+++ b/src/schemaview/tests/prefixed_names.rs
@@ -1,0 +1,26 @@
+use linkml_schemaview::identifier::{converter_from_schemas, Identifier};
+use linkml_schemaview::io::from_yaml;
+use linkml_schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn lookup_prefixed_names() {
+    let schema = from_yaml(Path::new(&data_path("prefixed_names.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schemas([&schema]);
+
+    let class = sv.get_class(&Identifier::new("geo:Geometry"), &conv).unwrap();
+    assert!(class.is_some());
+
+    let slot = sv.get_slot(&Identifier::new("geo:point"), &conv).unwrap();
+    assert!(slot.is_some());
+}


### PR DESCRIPTION
## Summary
- detect CURIE-like class and slot names when indexing schemas
- add test schema containing prefixed class/slot names
- verify lookup of `geo:Geometry` class and `geo:point` slot

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685d32d331b883299281cea15cad0a79