### PR TITLE
Handle inlined dict values

### DIFF
--- a/src/runtime/tests/convert.rs
+++ b/src/runtime/tests/convert.rs
@@ -2,7 +2,7 @@ use linkml_runtime::{
     load_yaml_file,
     turtle::{turtle_to_string, TurtleOptions},
 };
-use linkml_schemaview::identifier::converter_from_schema;
+use linkml_schemaview::identifier::{converter_from_schema, Identifier};
 use linkml_schemaview::io::from_yaml;
 use linkml_schemaview::schemaview::SchemaView;
 use std::path::{Path, PathBuf};
@@ -21,7 +21,17 @@ fn convert_person_to_ttl() {
     let mut sv = SchemaView::new();
     sv.add_schema(schema.clone()).unwrap();
     let conv = converter_from_schema(&schema);
-    let v = load_yaml_file(Path::new(&data_path("person_valid.yaml")), &sv, None, &conv).unwrap();
+    let class = sv
+        .get_class(&Identifier::new("Person"), &conv)
+        .unwrap()
+        .unwrap();
+    let v = load_yaml_file(
+        Path::new(&data_path("person_valid.yaml")),
+        &sv,
+        Some(&class),
+        &conv,
+    )
+    .unwrap();
     let ttl = turtle_to_string(&v, &sv, &schema, &conv, TurtleOptions { skolem: false }).unwrap();
     assert!(ttl.contains("@prefix test: <https://example.com/test/> ."));
     assert!(ttl.contains("<test:name> \"Alice\""));


### PR DESCRIPTION
## Summary
- enforce slot container modes when parsing values
- inject key slot values when loading mapping containers
- specify class for TTL conversion test

## Testing
- `cargo check -q`
- `cargo test -p linkml_runtime --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685e4fdabf248329a0cf3c32d8402a99