### PR TITLE
Suppress objecttype triple in Turtle output

### DIFF
--- a/src/runtime/src/turtle.rs
+++ b/src/runtime/src/turtle.rs
@@ -127,6 +127,14 @@ fn serialize_map<W: Write>(
         if id_slot.map(|s| s == k.as_str()).unwrap_or(false) {
             continue;
         }
+        let skip = match v {
+            LinkMLValue::Scalar { slot, .. } => slot.definition().designates_type.unwrap_or(false),
+            LinkMLValue::List { slot, .. } => slot.definition().designates_type.unwrap_or(false),
+            _ => false,
+        };
+        if skip {
+            continue;
+        }
         let pred_iri = format!("{}:{}", state.default_prefix, k);
         let predicate = NamedNode { iri: &pred_iri };
         match v {

--- a/src/runtime/tests/convert.rs
+++ b/src/runtime/tests/convert.rs
@@ -36,3 +36,24 @@ fn convert_person_to_ttl() {
     assert!(ttl.contains("@prefix test: <https://example.com/test/> ."));
     assert!(ttl.contains("<test:name> \"Alice\""));
 }
+
+#[test]
+fn suppress_objecttype_triple() {
+    let schema = from_yaml(Path::new(&data_path("personinfo.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let container = sv
+        .get_class(&Identifier::new("Container"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let v = load_yaml_file(
+        Path::new(&data_path("example_personinfo_data.yaml")),
+        &sv,
+        Some(&container),
+        &conv,
+    )
+    .unwrap();
+    let ttl = turtle_to_string(&v, &sv, &schema, &conv, TurtleOptions { skolem: false }).unwrap();
+    assert!(!ttl.contains("<personinfo:objecttype>"));
+}


### PR DESCRIPTION
## Summary
- skip generating triples for slots that designate type when serializing to turtle
- add regression test for objecttype suppression

## Testing
- `cargo test --tests suppress_objecttype_triple -- --nocapture`
- `cargo test --quiet`
- `cargo run --bin linkml-convert -- src/runtime/tests/data/personinfo.yaml src/runtime/tests/data/example_personinfo_data.yaml | head -n 30`

------
https://chatgpt.com/codex/tasks/task_e_685e7e92662c832980f924c68817d2ce