### PR TITLE
Implement deterministic skolemization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "linkml_meta",
  "oxrdf",
  "oxttl",
+ "percent-encoding",
  "predicates 2.1.5",
  "pyo3",
  "regex",

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -41,6 +41,7 @@ pyo3 = { version = "0.25.0", optional = true }
 serde_yml = "0.0.12"
 serde_path_to_error = "0.1.17"
 regex = "1"
+percent-encoding = "2.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/runtime/tests/cli.rs
+++ b/src/runtime/tests/cli.rs
@@ -24,7 +24,7 @@ fn skolem_flag_creates_named_nodes() {
     cmd.assert().success();
 
     let ttl = std::fs::read_to_string(&out_path).unwrap();
-    assert!(ttl.contains("poly:gen1"));
+    assert!(ttl.contains("poly:root/gen1"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- generate IRIs for skolem nodes based on parent IDs
- percent encode path parts for safety
- update CLI test to check for new behaviour

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685e98fd16948329af9237e37cb12c34