### PR TITLE
Improve slot resolution for CLI

### DIFF
--- a/src/runtime/tests/cli.rs
+++ b/src/runtime/tests/cli.rs
@@ -37,3 +37,13 @@ fn convert_personinfo_cli() {
         .success()
         .stdout(predicates::str::contains("@prefix P:"));
 }
+
+#[test]
+fn convert_meta_self_hosting() {
+    let schema = data_path("meta.yaml");
+    let mut cmd = Command::cargo_bin("linkml-convert").unwrap();
+    cmd.arg(&schema).arg(&schema);
+    cmd.assert()
+        .failure()
+        .stderr(predicates::str::contains("slots.abstract.description"));
+}


### PR DESCRIPTION
## Summary
- handle slot names that use spaces or underscores interchangeably
- enhance loader to match alt slot names when parsing
- show clearer error path for scalar slots
- add regression test for self-hosting meta.yaml

## Testing
- `cargo test --manifest-path src/runtime/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_685ee4cd6e408329b00e0f5efdd9716c