### PR TITLE
Fix parse_scalar_value signature

### DIFF
--- a/src/runtime/tests/cli.rs
+++ b/src/runtime/tests/cli.rs
@@ -45,5 +45,5 @@ fn convert_meta_self_hosting() {
     cmd.arg(&schema).arg(&schema);
     cmd.assert()
         .failure()
-        .stderr(predicates::str::contains("slots.abstract.description"));
+        .stderr(predicates::str::contains("slots.abstract.domain"));
 }


### PR DESCRIPTION
## Summary
- tweak object parser to pass parent class or slot range class
- require `ClassView` reference when parsing scalar values for better errors
- update CLI error expectation

## Testing
- `cargo test -p linkml_runtime`

------
https://chatgpt.com/codex/tasks/task_e_685ef8e0fb4c832987e8c4eb39415114