### PR TITLE
Add initial WASM support with basic greet function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,6 +913,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkml-core-wasm"
+version = "0.1.0"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "linkml_meta"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members=[
     "src/metamodel",
     "src/schemaview",
     "src/runtime",
+    "src/wasm",
 ]
 resolver = "2"

--- a/src/wasm/Cargo.toml
+++ b/src/wasm/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "linkml-core-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+

--- a/src/wasm/src/lib.rs
+++ b/src/wasm/src/lib.rs
@@ -1,0 +1,7 @@
+use wasm_bindgen::prelude::*;
+
+/// Simple greeting function to test wasm build
+#[wasm_bindgen]
+pub fn greet() -> String {
+    "Hello from linkml wasm".to_string()
+}


### PR DESCRIPTION
## Summary
- add `linkml-core-wasm` crate using wasm-bindgen for WebAssembly builds
- expose simple `greet` function for JavaScript integration
- register WASM crate in workspace

## Testing
- `cargo test -p linkml-core-wasm`
- `cargo test -p linkml_runtime`
- `cargo build -p linkml-core-wasm --target wasm32-unknown-unknown`

------
https://chatgpt.com/codex/tasks/task_e_689deacaeb1c8329a05831f7c4b14c24