### PR TITLE
Expose LinkMLValue directly to Python

### DIFF
--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -57,6 +57,7 @@ fn slot_matches_key(slot: &SlotView, key: &str) -> bool {
     false
 }
 
+#[derive(Clone)]
 pub enum LinkMLValue {
     Scalar {
         value: JsonValue,


### PR DESCRIPTION
## Summary
- remove LinkMLValueOwned and wrap LinkMLValue directly in PyLinkMLValue
- derive `Clone` for LinkMLValue so values can be cloned for Python access

## Testing
- `cargo test -p linkml_runtime --features python`


------
https://chatgpt.com/codex/tasks/task_e_68a2d434e7688329b1ac773a0d2e4c67