### PR TITLE
feat: feature-gated schema import resolution and python urllib resolver

### DIFF
--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -28,7 +28,7 @@ name = "linkml-schema-validate"
 path = "src/bin/linkml_schema_validate.rs"
 
 [dependencies]
-linkml_schemaview = { package = "schemaview", path = "../schemaview" }
+linkml_schemaview = { package = "schemaview", path = "../schemaview", default-features = false }
 serde_json = "1.0"
 serde_yaml = "0.9"
 serde = { version = "1.0", features = ["derive"] }
@@ -49,5 +49,7 @@ predicates = "2"
 tempfile = "3"
 
 [features]
+default = ["resolve"]
 python = ["pyo3", "linkml_meta/pyo3"]
 extension-module = ["pyo3/extension-module"]
+resolve = ["linkml_schemaview/resolve"]

--- a/src/runtime/pyproject.toml
+++ b/src/runtime/pyproject.toml
@@ -14,3 +14,5 @@ dynamic = ["version"]
 
 [tool.maturin]
 features = ["pyo3/extension-module", "python"]
+module-name = "linkml_runtime.linkml_runtime"
+python-source = "python"

--- a/src/runtime/python/linkml_runtime/__init__.py
+++ b/src/runtime/python/linkml_runtime/__init__.py
@@ -1,0 +1,11 @@
+"""Python package for :mod:`linkml_runtime` bindings."""
+
+from .linkml_runtime import *  # noqa: F401,F403
+from .linkml_runtime.linkml_schemaview import *  # noqa: F401,F403
+from ._resolver import resolve_schemas as _resolve_schemas
+
+# Attach the Python implementation of ``resolve_schemas`` to ``SchemaView``
+SchemaView.resolve_schemas = _resolve_schemas  # type: ignore[attr-defined]
+
+__all__ = [name for name in globals() if not name.startswith("_")]
+

--- a/src/runtime/python/linkml_runtime/_resolver.py
+++ b/src/runtime/python/linkml_runtime/_resolver.py
@@ -1,0 +1,31 @@
+"""Schema import resolution implemented in pure Python."""
+
+from pathlib import Path
+from urllib.request import urlopen
+
+
+_KNOWN_IMPORTS = {
+    "https://w3id.org/linkml/mappings": "https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/mappings.yaml",
+    "https://w3id.org/linkml/types": "https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/types.yaml",
+    "https://w3id.org/linkml/extensions": "https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/extensions.yaml",
+    "https://w3id.org/linkml/annotations": "https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/annotations.yaml",
+    "https://w3id.org/linkml/units": "https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/units.yaml",
+}
+
+
+def resolve_schemas(self) -> None:
+    """Resolve any imported schemas using Python's ``urllib``.
+
+    This mirrors the Rust implementation but avoids a dependency on ``reqwest``
+    by using the standard library for network access.
+    """
+
+    for schema_id, uri in self.get_unresolved_schema_refs():
+        target = _KNOWN_IMPORTS.get(uri, uri)
+        if Path(target).exists():
+            text = Path(target).read_text()
+        else:
+            with urlopen(target) as resp:  # nosec: B310 - controlled URLs
+                text = resp.read().decode("utf-8")
+        self.add_schema_str_with_import_ref(text, schema_id, uri)
+

--- a/src/runtime/src/bin/linkml_convert.rs
+++ b/src/runtime/src/bin/linkml_convert.rs
@@ -5,6 +5,7 @@ use linkml_runtime::{
     validate,
 };
 use linkml_schemaview::io::from_yaml;
+#[cfg(feature = "resolve")]
 use linkml_schemaview::resolve::resolve_schemas;
 use linkml_schemaview::schemaview::SchemaView;
 use std::fs::File;
@@ -32,9 +33,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let schema = from_yaml(&args.schema)?;
     let mut sv = SchemaView::new();
     sv.add_schema(schema.clone()).map_err(|e| format!("{e}"))?;
-    eprintln!("Resolving schemas...");
-    resolve_schemas(&mut sv).map_err(|e| format!("{e}"))?;
-    eprintln!("Schemas resolved");
+    #[cfg(feature = "resolve")]
+    {
+        eprintln!("Resolving schemas...");
+        resolve_schemas(&mut sv).map_err(|e| format!("{e}"))?;
+        eprintln!("Schemas resolved");
+    }
     let conv = sv.converter();
     let class_view = sv.get_tree_root_or(args.class.as_deref()).ok_or_else(|| {
         format!(

--- a/src/runtime/src/bin/linkml_diff.rs
+++ b/src/runtime/src/bin/linkml_diff.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use linkml_runtime::{diff, load_json_file, load_yaml_file};
 use linkml_schemaview::io::from_yaml;
+#[cfg(feature = "resolve")]
 use linkml_schemaview::resolve::resolve_schemas;
 use linkml_schemaview::schemaview::{ClassView, SchemaView};
 use std::fs::File;
@@ -46,6 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let schema = from_yaml(&args.schema)?;
     let mut sv = SchemaView::new();
     sv.add_schema(schema.clone()).map_err(|e| format!("{e}"))?;
+    #[cfg(feature = "resolve")]
     resolve_schemas(&mut sv).map_err(|e| format!("{e}"))?;
     let conv = sv.converter();
     let class_view = sv.get_tree_root_or(args.class.as_deref()).ok_or_else(|| {

--- a/src/runtime/src/bin/linkml_patch.rs
+++ b/src/runtime/src/bin/linkml_patch.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use linkml_runtime::{load_json_file, load_yaml_file, patch, Delta};
 use linkml_schemaview::io::from_yaml;
+#[cfg(feature = "resolve")]
 use linkml_schemaview::resolve::resolve_schemas;
 use linkml_schemaview::schemaview::{ClassView, SchemaView};
 use std::fs::File;
@@ -69,6 +70,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let schema = from_yaml(&args.schema)?;
     let mut sv = SchemaView::new();
     sv.add_schema(schema.clone()).map_err(|e| format!("{e}"))?;
+    #[cfg(feature = "resolve")]
     resolve_schemas(&mut sv).map_err(|e| format!("{e}"))?;
     let conv = sv.converter();
     let class_view = sv.get_tree_root_or(args.class.as_deref()).ok_or_else(|| {

--- a/src/runtime/src/bin/linkml_validate.rs
+++ b/src/runtime/src/bin/linkml_validate.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use linkml_runtime::{load_json_file, load_yaml_file, validate_errors};
 use linkml_schemaview::identifier::Identifier;
 use linkml_schemaview::io::from_yaml;
+#[cfg(feature = "resolve")]
 use linkml_schemaview::resolve::resolve_schemas;
 use linkml_schemaview::schemaview::SchemaView;
 use std::path::PathBuf;
@@ -21,6 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let schema = from_yaml(&args.schema)?;
     let mut sv = SchemaView::new();
     sv.add_schema(schema.clone()).map_err(|e| format!("{e}"))?;
+    #[cfg(feature = "resolve")]
     resolve_schemas(&mut sv).map_err(|e| format!("{e}"))?;
     let conv = sv.converter();
     let class_view = sv

--- a/src/schemaview/Cargo.toml
+++ b/src/schemaview/Cargo.toml
@@ -13,5 +13,14 @@ linkml_meta = { path = "../metamodel" }
 serde_yml = "0.0.12"
 itertools = "0.14.0"
 serde_path_to_error = "0.1.17"
-reqwest = { version = "0.12.16", default-features = false, features = ["blocking", "rustls-tls"] }
 curies = "0.1.3"
+
+[dependencies.reqwest]
+version = "0.12.16"
+default-features = false
+features = ["blocking", "rustls-tls"]
+optional = true
+
+[features]
+default = ["resolve"]
+resolve = ["reqwest"]

--- a/src/schemaview/src/io.rs
+++ b/src/schemaview/src/io.rs
@@ -15,6 +15,7 @@ pub fn from_yaml(path: &Path) -> Result<SchemaDefinition, Box<dyn Error>> {
     Ok(result?)
 }
 
+#[cfg(feature = "resolve")]
 pub fn from_uri(uri: &str) -> Result<SchemaDefinition, Box<dyn Error>> {
     let r = reqwest::blocking::get(uri)?;
     let reader = r.text()?;
@@ -41,8 +42,6 @@ mod tests {
         this_file
     }
 
-    use crate::resolve::resolve_schemas;
-
     use super::*;
     #[test]
     fn test_load_schema() {
@@ -68,6 +67,10 @@ mod tests {
         };
     }
 
+    #[cfg(feature = "resolve")]
+    use crate::resolve::resolve_schemas;
+
+    #[cfg(feature = "resolve")]
     #[test]
     fn test_resolve_schemas() {
         let path = &meta_path();
@@ -79,7 +82,11 @@ mod tests {
         let mut schema_view = SchemaView::new();
         schema_view.add_schema(schema).unwrap();
         let unresolved = schema_view.get_unresolved_schemas();
-        assert!(unresolved.iter().map(|x| x.1.clone()).collect::<Vec<_>>().contains(&"https://w3id.org/linkml/mappings".to_string()));
+        assert!(unresolved
+            .iter()
+            .map(|x| x.1.clone())
+            .collect::<Vec<_>>()
+            .contains(&"https://w3id.org/linkml/mappings".to_string()));
         println!("Unresolved schemas: {:?}", unresolved);
         resolve_schemas(&mut schema_view).unwrap();
         let unresolved = schema_view.get_unresolved_schemas();

--- a/src/schemaview/src/lib.rs
+++ b/src/schemaview/src/lib.rs
@@ -2,6 +2,7 @@ pub mod classview;
 pub mod curie;
 pub mod identifier;
 pub mod io;
+#[cfg(feature = "resolve")]
 pub mod resolve;
 pub mod schemaview;
 pub mod slotview;

--- a/src/schemaview/tests/local_import.rs
+++ b/src/schemaview/tests/local_import.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "resolve")]
+
 use linkml_schemaview::io::from_yaml;
 use linkml_schemaview::resolve::resolve_schemas;
 use linkml_schemaview::schemaview::SchemaView;
@@ -16,7 +18,11 @@ fn resolve_local_import() {
     let schema = from_yaml(Path::new(&data_path("local_main.yaml"))).unwrap();
     let mut sv = SchemaView::new();
     sv.add_schema(schema).unwrap();
-    let unresolved = sv.get_unresolved_schemas().iter().map(|x| x.1.clone()).collect::<Vec<_>>();
+    let unresolved = sv
+        .get_unresolved_schemas()
+        .iter()
+        .map(|x| x.1.clone())
+        .collect::<Vec<_>>();
     assert!(unresolved.contains(&"tests/data/local_target.yaml".to_string()));
     resolve_schemas(&mut sv).unwrap();
     let unresolved = sv.get_unresolved_schemas();


### PR DESCRIPTION
## Summary
- gate reqwest-based schema import resolution behind a `resolve` feature
- expose Python `resolve_schemas` implementation via `urllib` in a separate module
- allow runtime binaries to compile without network resolver

## Testing
- `cargo test` *(fails: Failed to load schema from https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/types.yaml: error sending request for url)*
- `cargo test -p linkml_runtime --features python` *(fails: Failed to load schema from https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/types.yaml: error sending request for url)*
- `cargo check --workspace --no-default-features`
- `cargo check -p linkml_runtime --no-default-features --features python`


------
https://chatgpt.com/codex/tasks/task_e_68a2fc22b4b88329900d5d75a17ac64d