### PR TITLE
feat(runtime): support relative imports for schema resolution

### DIFF
--- a/src/runtime/python/linkml_runtime/__init__.py
+++ b/src/runtime/python/linkml_runtime/__init__.py
@@ -2,10 +2,7 @@
 
 from .linkml_runtime import *  # noqa: F401,F403
 from .linkml_runtime.linkml_schemaview import *  # noqa: F401,F403
-from ._resolver import resolve_schemas as _resolve_schemas
-
-# Attach the Python implementation of ``resolve_schemas`` to ``SchemaView``
-SchemaView.resolve_schemas = _resolve_schemas  # type: ignore[attr-defined]
+from ._resolver import resolve_schemas
 
 __all__ = [name for name in globals() if not name.startswith("_")]
 

--- a/src/runtime/python/linkml_runtime/_resolver.py
+++ b/src/runtime/python/linkml_runtime/_resolver.py
@@ -2,6 +2,10 @@
 
 from pathlib import Path
 from urllib.request import urlopen
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .linkml_runtime.linkml_schemaview import SchemaView
 
 
 _KNOWN_IMPORTS = {
@@ -13,19 +17,35 @@ _KNOWN_IMPORTS = {
 }
 
 
-def resolve_schemas(self) -> None:
+def resolve_schemas(sv: "SchemaView") -> None:
     """Resolve any imported schemas using Python's ``urllib``.
 
     This mirrors the Rust implementation but avoids a dependency on ``reqwest``
-    by using the standard library for network access.
+    by using the standard library for network access. Local paths are resolved
+    relative to the schema containing the import statement.
     """
 
-    for schema_id, uri in self.get_unresolved_schema_refs():
+    for schema_id, uri in sv.get_unresolved_schema_refs():
         target = _KNOWN_IMPORTS.get(uri, uri)
-        if Path(target).exists():
-            text = Path(target).read_text()
+
+        path = Path(target)
+        if not path.exists():
+            if not path.is_absolute():
+                schema_source_uri = sv.get_resolution_uri_of_schema(schema_id)
+                if schema_source_uri:
+                    imported_from_dir = Path(schema_source_uri).parent
+                    if imported_from_dir:
+                        path = imported_from_dir / path
+                if not path.exists() and path.with_suffix(".yaml").exists():
+                    path = path.with_suffix(".yaml")
+                if not path.exists() and path.with_suffix(".yml").exists():
+                    path = path.with_suffix(".yml")
+
+        if path.exists():
+            text = path.read_text()
         else:
             with urlopen(target) as resp:  # nosec: B310 - controlled URLs
                 text = resp.read().decode("utf-8")
-        self.add_schema_str_with_import_ref(text, schema_id, uri)
+
+        sv.add_schema_str_with_import_ref(text, schema_id, uri)
 


### PR DESCRIPTION
## Summary
- add standalone `resolve_schemas` helper to load imports relative to the importing schema
- expose `resolve_schemas` directly without monkeypatching `SchemaView`

## Testing
- `python -m py_compile src/runtime/python/linkml_runtime/_resolver.py src/runtime/python/linkml_runtime/__init__.py`
- `cargo test -p linkml_runtime` *(fails: Failed to load schema from https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/types.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68a33d01a05c83299a22852670f2641c