### PR TITLE
Expose definition iteration in Python SchemaView

### DIFF
--- a/src/runtime/src/python.rs
+++ b/src/runtime/src/python.rs
@@ -1,6 +1,6 @@
 use crate::turtle::{turtle_to_string, TurtleOptions};
 use crate::{load_json_str, load_yaml_str, LinkMLValue};
-use linkml_meta::{ClassDefinition, SchemaDefinition};
+use linkml_meta::{ClassDefinition, SchemaDefinition, SlotDefinition};
 use linkml_schemaview::identifier::Identifier;
 use linkml_schemaview::io;
 use linkml_schemaview::schemaview::SchemaView;
@@ -160,6 +160,30 @@ impl PySchemaView {
                 _sv: self.inner.clone(),
             }))
     }
+
+    fn schema_definitions(&self) -> Vec<SchemaDefinition> {
+        self.inner.iter_schemas().map(|(_, s)| s.clone()).collect()
+    }
+
+    fn class_definitions(&self) -> Vec<ClassDefinition> {
+        let mut defs = Vec::new();
+        for (_, schema) in self.inner.iter_schemas() {
+            if let Some(classes) = &schema.classes {
+                defs.extend(classes.values().cloned());
+            }
+        }
+        defs
+    }
+
+    fn slot_definitions(&self) -> Vec<SlotDefinition> {
+        let mut defs = Vec::new();
+        for (_, schema) in self.inner.iter_schemas() {
+            if let Some(slots) = &schema.slot_definitions {
+                defs.extend(slots.values().cloned());
+            }
+        }
+        defs
+    }
 }
 
 #[pymethods]
@@ -205,6 +229,7 @@ pub fn schemaview_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySlotView>()?;
     m.add_class::<SchemaDefinition>()?;
     m.add_class::<ClassDefinition>()?;
+    m.add_class::<SlotDefinition>()?;
     Ok(())
 }
 

--- a/src/runtime/tests/python_api.rs
+++ b/src/runtime/tests/python_api.rs
@@ -73,3 +73,35 @@ assert c is not None and c.name == 'class_definition'
         );
     });
 }
+
+#[test]
+fn iterate_definitions_via_python() {
+    pyo3::prepare_freethreaded_python();
+    let yaml = std::fs::read_to_string(meta_path()).unwrap();
+    Python::with_gil(|py| {
+        let module = PyModule::new(py, "linkml_runtime").unwrap();
+        runtime_module(&module).unwrap();
+        let sys = py.import("sys").unwrap();
+        let modules = sys.getattr("modules").unwrap();
+        let sys_modules = modules.downcast::<PyDict>().unwrap();
+        sys_modules.set_item("linkml_runtime", module).unwrap();
+
+        let locals = PyDict::new(py);
+        locals.set_item("meta_yaml", &yaml).unwrap();
+        pyo3::py_run!(
+            py,
+            *locals,
+            r#"
+import linkml_runtime as lr
+sv = lr.make_schema_view()
+sv.add_schema_str(meta_yaml)
+cls = sv.class_definitions()
+assert any(c.name == 'class_definition' for c in cls)
+slots = sv.slot_definitions()
+assert any(s.name == 'name' for s in slots)
+schemas = sv.schema_definitions()
+assert any(s.name == 'meta' for s in schemas)
+"#
+        );
+    });
+}


### PR DESCRIPTION
## Summary
- add methods to Python SchemaView for listing schema, class, and slot definitions
- expose SlotDefinition class in Python module
- test iteration over definitions via Python API

## Testing
- `cargo test -p linkml_runtime --features python --test python_api`
- `cargo test -p linkml_runtime --features python` *(fails: Failed to load schema from https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/types.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68a43e414acc8329a2b298e83cb7a395