### PR TITLE
Add lazy class and slot accessors in SchemaView Python API

### DIFF
--- a/src/runtime/python/linkml_runtime_rust/schemaview.py
+++ b/src/runtime/python/linkml_runtime_rust/schemaview.py
@@ -7,3 +7,42 @@ __all__ = getattr(_mod, "__all__", [])
 for name in dir(_mod):
     if not name.startswith("_") or name in __all__:
         globals()[name] = getattr(_mod, name)
+
+
+class _LazyClassGetter:
+    def __init__(self, sv: "SchemaView") -> None:
+        self._sv = sv
+
+    def __iter__(self):
+        return iter(self._sv.get_class_ids())
+
+    def keys(self):
+        return self._sv.get_class_ids()
+
+    def __getitem__(self, cid: str):
+        cv = self._sv.get_class_view(cid)
+        if cv is None:
+            raise KeyError(cid)
+        return cv
+
+
+class _LazySlotGetter:
+    def __init__(self, sv: "SchemaView") -> None:
+        self._sv = sv
+
+    def __iter__(self):
+        return iter(self._sv.get_slot_ids())
+
+    def keys(self):
+        return self._sv.get_slot_ids()
+
+    def __getitem__(self, sid: str):
+        sv = self._sv.get_slot_view(sid)
+        if sv is None:
+            raise KeyError(sid)
+        return sv
+
+
+SchemaView.classes = property(lambda self: _LazyClassGetter(self))
+SchemaView.slots = property(lambda self: _LazySlotGetter(self))
+

--- a/src/runtime/src/python.rs
+++ b/src/runtime/src/python.rs
@@ -12,7 +12,7 @@ use pyo3::types::{PyAny, PyModule};
 use pyo3::Bound;
 use pyo3::{wrap_pyfunction, wrap_pymodule};
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -186,34 +186,24 @@ impl PySchemaView {
         self.inner.iter_schemas().map(|(_, s)| s.clone()).collect()
     }
 
-    fn class_definitions(&self) -> Vec<PyClassView> {
-        let mut defs = Vec::new();
-        let conv = self.inner.converter();
+    fn get_class_ids(&self) -> Vec<String> {
+        let mut ids: HashSet<String> = HashSet::new();
         for (_, schema) in self.inner.iter_schemas() {
             if let Some(classes) = &schema.classes {
-                for name in classes.keys() {
-                    if let Ok(Some(cv)) = self.inner.get_class(&Identifier::new(name), &conv) {
-                        defs.push(PyClassView { inner: cv });
-                    }
-                }
+                ids.extend(classes.keys().cloned());
             }
         }
-        defs
+        ids.into_iter().collect()
     }
 
-    fn slot_definitions(&self) -> Vec<PySlotView> {
-        let mut defs = Vec::new();
-        let conv = self.inner.converter();
+    fn get_slot_ids(&self) -> Vec<String> {
+        let mut ids: HashSet<String> = HashSet::new();
         for (_, schema) in self.inner.iter_schemas() {
             if let Some(slots) = &schema.slot_definitions {
-                for name in slots.keys() {
-                    if let Ok(Some(sv)) = self.inner.get_slot(&Identifier::new(name), &conv) {
-                        defs.push(PySlotView { inner: sv });
-                    }
-                }
+                ids.extend(slots.keys().cloned());
             }
         }
-        defs
+        ids.into_iter().collect()
     }
 }
 


### PR DESCRIPTION
## Summary
- expose `get_class_ids` and `get_slot_ids` on `SchemaView`
- add Python-side lazy `classes` and `slots` accessors using monkeypatching

## Testing
- `cargo test -p schemaview --lib` *(fails: timed out/aborted due to long compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68a464a28be88329b367107d3ac8c4cc