### PR TITLE
Add informative repr for SchemaView and views

### DIFF
--- a/src/runtime/src/python.rs
+++ b/src/runtime/src/python.rs
@@ -12,7 +12,7 @@ use pyo3::types::{PyAny, PyModule};
 use pyo3::Bound;
 use pyo3::{wrap_pyfunction, wrap_pymodule};
 use serde_json::Value as JsonValue;
-use std::collections::{HashMap};
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -187,12 +187,15 @@ impl PySchemaView {
     }
 
     fn schema_ids(&self) -> Vec<String> {
-        self.inner.all_schema_definitions().map(|x| x.0.clone()).collect()
+        self.inner
+            .all_schema_definitions()
+            .map(|x| x.0.clone())
+            .collect()
     }
 
     fn get_class_ids(&self) -> Vec<String> {
         return self.inner.get_class_ids();
-        /* 
+        /*
         let mut ids: HashSet<String> = HashSet::new();
         for (_, schema) in self.inner.iter_schemas() {
             if let Some(classes) = &schema.classes {
@@ -206,16 +209,29 @@ impl PySchemaView {
 
     fn get_slot_ids(&self) -> Vec<String> {
         return self.inner.get_slot_ids(); /*
-        let mut ids: HashSet<String> = HashSet::new();
-        for (_, schema) in self.inner.iter_schemas() {
-            if let Some(slots) = &schema.slot_definitions {
-                slots.iter().map(|c| self.inner.get_uri(&schema.id, c.0)).for_each(|uri| {
-                    ids.insert(uri.to_string());
-                });
-            }
-        }
-        ids.into_iter().collect()*/
-    } 
+                                          let mut ids: HashSet<String> = HashSet::new();
+                                          for (_, schema) in self.inner.iter_schemas() {
+                                              if let Some(slots) = &schema.slot_definitions {
+                                                  slots.iter().map(|c| self.inner.get_uri(&schema.id, c.0)).for_each(|uri| {
+                                                      ids.insert(uri.to_string());
+                                                  });
+                                              }
+                                          }
+                                          ids.into_iter().collect()*/
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "SchemaView(n_schemas={}, n_classes={}, n_slots={})",
+            self.inner.all_schema_definitions().count(),
+            self.inner.get_class_ids().len(),
+            self.inner.get_slot_ids().len()
+        ))
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        self.__repr__()
+    }
 }
 
 #[pymethods]
@@ -273,6 +289,18 @@ impl PyClassView {
     fn canonical_uri(&self) -> String {
         self.inner.canonical_uri().to_string()
     }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "ClassView(name='{}', slots={})",
+            self.inner.name(),
+            self.inner.slots().len()
+        ))
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        self.__repr__()
+    }
 }
 
 #[pymethods]
@@ -307,6 +335,24 @@ impl PySlotView {
 
     fn inline_mode(&self) -> String {
         format!("{:?}", self.inner.determine_slot_inline_mode())
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let range = self
+            .inner
+            .definition()
+            .range
+            .clone()
+            .unwrap_or_else(|| "None".to_string());
+        Ok(format!(
+            "SlotView(name='{}', range='{}')",
+            self.inner.name.clone(),
+            range
+        ))
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        self.__repr__()
     }
 }
 

--- a/src/runtime/tests/python_repr.rs
+++ b/src/runtime/tests/python_repr.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "python")]
+
+use linkml_runtime::runtime_module;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+#[test]
+fn python_reprs() {
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let module = PyModule::new(py, "linkml_runtime").unwrap();
+        runtime_module(&module).unwrap();
+        let sys = py.import("sys").unwrap();
+        let modules = sys.getattr("modules").unwrap();
+        let sys_modules = modules.downcast::<PyDict>().unwrap();
+        sys_modules.set_item("linkml_runtime", module).unwrap();
+
+        let locals = PyDict::new(py);
+        locals
+            .set_item(
+                "schema_yaml",
+                r#"id: test
+name: test
+prefixes:
+  test: https://example.org/
+default_prefix: test
+classes:
+  Person:
+    slots:
+      - name
+slots:
+  name:
+    range: string
+"#,
+            )
+            .unwrap();
+        pyo3::py_run!(
+            py,
+            *locals,
+            r#"
+import linkml_runtime as lr
+sv = lr.make_schema_view()
+sv.add_schema_str(schema_yaml)
+cv = sv.get_class_view('Person')
+svw = sv.get_slot_view('name')
+assert repr(sv) == 'SchemaView(n_schemas=1, n_classes=1, n_slots=1)'
+assert repr(cv) == "ClassView(name='Person', slots=1)"
+assert repr(svw) == "SlotView(name='name', range='string')"
+"#
+        );
+    });
+}


### PR DESCRIPTION
## Summary
- make `SchemaView`, `ClassView`, and `SlotView` show concise details in notebooks
- add regression test for Python representations

## Testing
- `cargo test` *(fails: Failed to load schema from https://raw.githubusercontent.com/linkml/linkml-model/...)*
- `cargo test -p linkml_runtime --features python --test python_repr`


------
https://chatgpt.com/codex/tasks/task_e_68a48097b0f883299620be98f1b0f55a