### PR TITLE
Add __repr__ for PyLinkMLValue

### DIFF
--- a/src/runtime/src/python.rs
+++ b/src/runtime/src/python.rs
@@ -509,6 +509,33 @@ impl PyLinkMLValue {
         )
         .map_err(|e| PyException::new_err(e.to_string()))
     }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(match &self.value {
+            LinkMLValue::Scalar { value, slot, .. } => {
+                format!("LinkMLValue.Scalar(slot='{}', value={})", slot.name, value)
+            }
+            LinkMLValue::List { values, slot, .. } => {
+                format!(
+                    "LinkMLValue.List(slot='{}', len={})",
+                    slot.name,
+                    values.len()
+                )
+            }
+            LinkMLValue::Map { values, class, .. } => {
+                let keys: Vec<&String> = values.keys().collect();
+                format!(
+                    "LinkMLValue.Map(class='{}', keys={:?})",
+                    class.def().name.clone(),
+                    keys
+                )
+            }
+        })
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        self.__repr__()
+    }
 }
 
 #[pyfunction]


### PR DESCRIPTION
## Summary
- provide a __repr__ implementation for Python LinkMLValue bindings

## Testing
- `cargo test` *(fails: convert_personinfo_cli, convert_meta_self_hosting - unable to fetch remote schema)*

------
https://chatgpt.com/codex/tasks/task_e_68a49b2906a08329866e55d3be9a3c3b