### PR TITLE
Expose slot and class definitions in Python API

### DIFF
--- a/src/runtime/src/python.rs
+++ b/src/runtime/src/python.rs
@@ -415,10 +415,30 @@ impl Clone for PyLinkMLValue {
 
 #[pymethods]
 impl PyLinkMLValue {
+    #[getter]
     fn slot_name(&self) -> Option<String> {
         match &self.value {
             LinkMLValue::Scalar { slot, .. } => Some(slot.name.clone()),
             LinkMLValue::List { slot, .. } => Some(slot.name.clone()),
+            _ => None,
+        }
+    }
+
+    #[getter]
+    fn slot_definition(&self) -> Option<SlotDefinition> {
+        match &self.value {
+            LinkMLValue::Scalar { slot, .. } => Some(slot.definition().clone()),
+            LinkMLValue::List { slot, .. } => Some(slot.definition().clone()),
+            _ => None,
+        }
+    }
+
+    #[getter]
+    fn class_definition(&self) -> Option<ClassDefinition> {
+        match &self.value {
+            LinkMLValue::Map { class, .. } => Some(class.def().clone()),
+            LinkMLValue::Scalar { class: Some(c), .. } => Some(c.def().clone()),
+            LinkMLValue::List { class: Some(c), .. } => Some(c.def().clone()),
             _ => None,
         }
     }

--- a/src/runtime/tests/python_value.rs
+++ b/src/runtime/tests/python_value.rs
@@ -44,7 +44,10 @@ sv = lr.make_schema_view(schema_path)
 cls = sv.get_class_view('Person')
 value = lr.load_yaml(person_path, sv, cls)
 assert value.class_name() == 'Person'
-assert value['name'].slot_name() == 'name'
+assert value.class_definition.name == 'Person'
+assert value['name'].slot_name == 'name'
+assert value['name'].slot_definition.name == 'name'
+assert value['name'].class_definition.name == 'Person'
 assert value['name'].as_python() == 'Alice'
 "#
         );


### PR DESCRIPTION
## Summary
- expose `slot_name` as a property on Python `LinkMLValue`
- provide optional `slot_definition` and `class_definition` properties
- update Python test for new property-based API

## Testing
- `cargo test -p linkml_runtime --features python` *(fails: Failed to load schema from https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/types.yaml: error sending request for url (https://raw.githubusercontent.com/linkml/linkml-model/refs/heads/main/linkml_model/model/schema/types.yaml))*
- `cargo test -p linkml_runtime --features python --test python_value`


------
https://chatgpt.com/codex/tasks/task_e_68a58424c5d48329a090e8c89567b286