### PR TITLE
fix(diff): match keyed lists by identifier instead of by position

### DIFF
--- a/src/runtime/src/blame/mod.rs
+++ b/src/runtime/src/blame/mod.rs
@@ -76,7 +76,7 @@ pub fn blame_map_to_paths<M: Clone>(
         match node {
             LinkMLInstance::Object { values, .. } | LinkMLInstance::Mapping { values, .. } => {
                 let mut entries: Vec<_> = values.iter().collect();
-                entries.sort_by(|(ka, _), (kb, _)| ka.cmp(kb));
+                entries.sort_by_key(|(k, _)| *k);
                 for (key, child) in entries {
                     path.push(key.clone());
                     collect_paths(child, blame, path, out);
@@ -170,7 +170,7 @@ pub fn format_blame_map_with<M>(
                 };
                 lines.push(format!("{meta_str} | {header}"));
                 let mut entries: Vec<_> = values.iter().collect();
-                entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                entries.sort_by_key(|(k, _)| *k);
                 for (child_key, child_value) in entries {
                     walk(
                         child_value,
@@ -192,7 +192,7 @@ pub fn format_blame_map_with<M>(
                 };
                 lines.push(format!("{meta_str} | {header}"));
                 let mut entries: Vec<_> = values.iter().collect();
-                entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                entries.sort_by_key(|(k, _)| *k);
                 for (child_key, child_value) in entries {
                     walk(
                         child_value,

--- a/src/runtime/src/diff.rs
+++ b/src/runtime/src/diff.rs
@@ -196,49 +196,90 @@ pub fn diff(source: &LinkMLInstance, target: &LinkMLInstance, opts: DiffOptions)
                 }
             }
             (LinkMLInstance::List { values: sl, .. }, LinkMLInstance::List { values: tl, .. }) => {
-                // Prefer identifier-based addressing when possible, fall back to index
-                let max_len = std::cmp::max(sl.len(), tl.len());
-                for i in 0..max_len {
-                    let label = |v: &LinkMLInstance| -> Option<String> {
-                        if let LinkMLInstance::Object { values, class, .. } = v {
-                            if let Some(id_slot) = class.key_or_identifier_slot() {
-                                if let Some(LinkMLInstance::Scalar { value, .. }) =
-                                    values.get(&id_slot.name)
-                                {
-                                    return match value {
-                                        JsonValue::String(s) => Some(s.clone()),
-                                        other => Some(other.to_string()),
-                                    };
-                                }
+                let label = |v: &LinkMLInstance| -> Option<String> {
+                    if let LinkMLInstance::Object { values, class, .. } = v {
+                        if let Some(id_slot) = class.key_or_identifier_slot() {
+                            if let Some(LinkMLInstance::Scalar { value, .. }) =
+                                values.get(&id_slot.name)
+                            {
+                                return match value {
+                                    JsonValue::String(s) => Some(s.clone()),
+                                    other => Some(other.to_string()),
+                                };
                             }
                         }
-                        None
-                    };
-                    let step = if let Some(sv) = sl.get(i) {
-                        label(sv)
-                            .or_else(|| tl.get(i).and_then(label))
-                            .unwrap_or_else(|| i.to_string())
-                    } else {
-                        tl.get(i).and_then(label).unwrap_or_else(|| i.to_string())
-                    };
-                    path.push(step);
-                    match (sl.get(i), tl.get(i)) {
-                        (Some(sv), Some(tv)) => inner(path, None, sv, tv, opts, out),
-                        (Some(sv), None) => out.push(Delta {
-                            path: path.clone(),
-                            op: DeltaOp::Remove,
-                            old: Some(sv.to_json()),
-                            new: None,
-                        }),
-                        (None, Some(tv)) => out.push(Delta {
-                            path: path.clone(),
-                            op: DeltaOp::Add,
-                            old: None,
-                            new: Some(tv.to_json()),
-                        }),
-                        (None, None) => {}
                     }
-                    path.pop();
+                    None
+                };
+                // If every item in both lists carries an identifier, match by id
+                // rather than by position. Positional diff corrupts mid-list
+                // removes/inserts into shifted Updates, and on patch the label
+                // resolver can remove the wrong duplicate.
+                let keyed =
+                    sl.iter().all(|v| label(v).is_some()) && tl.iter().all(|v| label(v).is_some());
+                if keyed {
+                    use std::collections::HashSet;
+                    let src_ids: HashSet<String> = sl.iter().filter_map(&label).collect();
+                    let tgt_by_id: std::collections::HashMap<String, &LinkMLInstance> = tl
+                        .iter()
+                        .filter_map(|v| label(v).map(|id| (id, v)))
+                        .collect();
+                    for sv in sl {
+                        let Some(id) = label(sv) else { continue };
+                        path.push(id.clone());
+                        match tgt_by_id.get(&id) {
+                            Some(tv) => inner(path, None, sv, tv, opts, out),
+                            None => out.push(Delta {
+                                path: path.clone(),
+                                op: DeltaOp::Remove,
+                                old: Some(sv.to_json()),
+                                new: None,
+                            }),
+                        }
+                        path.pop();
+                    }
+                    for tv in tl {
+                        let Some(id) = label(tv) else { continue };
+                        if !src_ids.contains(&id) {
+                            path.push(id);
+                            out.push(Delta {
+                                path: path.clone(),
+                                op: DeltaOp::Add,
+                                old: None,
+                                new: Some(tv.to_json()),
+                            });
+                            path.pop();
+                        }
+                    }
+                } else {
+                    let max_len = std::cmp::max(sl.len(), tl.len());
+                    for i in 0..max_len {
+                        let step = if let Some(sv) = sl.get(i) {
+                            label(sv)
+                                .or_else(|| tl.get(i).and_then(&label))
+                                .unwrap_or_else(|| i.to_string())
+                        } else {
+                            tl.get(i).and_then(&label).unwrap_or_else(|| i.to_string())
+                        };
+                        path.push(step);
+                        match (sl.get(i), tl.get(i)) {
+                            (Some(sv), Some(tv)) => inner(path, None, sv, tv, opts, out),
+                            (Some(sv), None) => out.push(Delta {
+                                path: path.clone(),
+                                op: DeltaOp::Remove,
+                                old: Some(sv.to_json()),
+                                new: None,
+                            }),
+                            (None, Some(tv)) => out.push(Delta {
+                                path: path.clone(),
+                                op: DeltaOp::Add,
+                                old: None,
+                                new: Some(tv.to_json()),
+                            }),
+                            (None, None) => {}
+                        }
+                        path.pop();
+                    }
                 }
             }
             (

--- a/src/runtime/tests/diff.rs
+++ b/src/runtime/tests/diff.rs
@@ -446,6 +446,73 @@ fn diff_mapping_ignore_missing_target() {
     );
 }
 
+/// Regression: removing an item from a list of inlined objects keyed by
+/// identifier must produce a clean `Remove` delta addressed by id, not a
+/// chain of shifted `Update` deltas. The bug is exposed when the removal is
+/// from the middle of the list AND a trailing item also changes: positional
+/// diff emits `Update(P:002→P:003')` + `Remove(P:003)`, and on patch the
+/// label-resolver picks the just-updated P:003 for removal, silently
+/// clobbering the trailing update.
+#[test]
+fn diff_and_patch_remove_from_keyed_list() {
+    let schema = from_yaml(Path::new(&info_path("personinfo.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let container = class_in_schema(&sv, &schema, "Container");
+
+    let src = load_json_instance(
+        r#"{
+            "objects": [
+                {"id":"P:001","name":"a","objecttype":"https://w3id.org/linkml/examples/personinfo/Person"},
+                {"id":"P:002","name":"b","objecttype":"https://w3id.org/linkml/examples/personinfo/Person"},
+                {"id":"P:003","name":"c","objecttype":"https://w3id.org/linkml/examples/personinfo/Person"}
+            ]
+        }"#,
+        &sv,
+        &container,
+        &conv,
+    );
+    let tgt = load_json_instance(
+        r#"{
+            "objects": [
+                {"id":"P:001","name":"a","objecttype":"https://w3id.org/linkml/examples/personinfo/Person"},
+                {"id":"P:003","name":"c-updated","objecttype":"https://w3id.org/linkml/examples/personinfo/Person"}
+            ]
+        }"#,
+        &sv,
+        &container,
+        &conv,
+    );
+
+    let deltas = diff(&src, &tgt, DiffOptions::default());
+    assert!(
+        deltas.iter().any(|d| d.op == DeltaOp::Remove
+            && d.path == vec!["objects".to_string(), "P:002".to_string()]),
+        "expected Remove at objects/P:002 for the removed keyed item, got: {deltas:?}"
+    );
+
+    let (patched, trace) = patch(
+        &src,
+        &deltas,
+        linkml_runtime::diff::PatchOptions {
+            ignore_no_ops: true,
+            treat_missing_as_null: false,
+        },
+    )
+    .unwrap();
+    assert!(
+        trace.failed.is_empty(),
+        "no delta should fail to apply, got failed: {:?}",
+        trace.failed
+    );
+    assert_eq!(
+        patched.to_json(),
+        tgt.to_json(),
+        "patched source should equal target after keyed-list remove"
+    );
+}
+
 #[test]
 fn diff_and_patch_multiple_removes_from_scalar_list() {
     // Regression: removing multiple items from an index-addressed list


### PR DESCRIPTION
## Summary
- `inlined_as_list` collections of keyed objects were diffed positionally, so a mid-list remove produced shifted `Update` deltas plus a trailing `Remove`. On patch, the label resolver picks the first matching id, so the `Remove` strikes the just-updated duplicate — a pure mid-list remove looks like a no-op, and removes combined with trailing edits lose the edits.
- Fix: when every element on both sides carries an identifier, match items by id. Emit a clean `Remove` for items only in the source, `Add` for items only in the target, and recurse on matched pairs. Lists of scalars or unkeyed objects keep the positional path; mappings were already key-matched.

## Test plan
- [x] `cargo test -p linkml_runtime --test diff` — new `diff_and_patch_remove_from_keyed_list` regression (remove-from-middle plus trailing field update) + 9 existing
- [x] `cargo test --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p schemaview -p linkml_runtime -p linkml_tools -p linkml_runtime_python -p linkml_wasm --all-targets --all-features -- -D warnings --no-deps`
- [x] `cargo run -p linkml_runtime_python --bin stub_gen --features stubgen -- --check`