### PR TITLE
refactor(diff)!: require explicit treat_missing_as_null

### DIFF
--- a/src/python/python/linkml_runtime_rust/_native.pyi
+++ b/src/python/python/linkml_runtime_rust/_native.pyi
@@ -5380,12 +5380,17 @@ class ValidationResult:
     def __repr__(self) -> builtins.str: ...
     def __str__(self) -> builtins.str: ...
 
-def diff(source:LinkMLInstance, target:LinkMLInstance, treat_missing_as_null:builtins.bool=False, treat_changed_identifier_as_new_object:builtins.bool=True) -> builtins.list[Delta]:
+def diff(source:LinkMLInstance, target:LinkMLInstance, treat_missing_as_null:builtins.bool, treat_changed_identifier_as_new_object:builtins.bool=True) -> builtins.list[Delta]:
     r"""
     Compute deltas between two instances.
-    
-    When ``treat_missing_as_null`` is ``False`` (default), object slots and
-    mapping keys that are present in ``source`` but absent in ``target`` are
+
+    ``treat_missing_as_null`` is required — callers must decide explicitly
+    whether absent entries mean "unchanged" or "removed", since the two
+    interpretations produce materially different deltas and silent
+    data-loss bugs have resulted from mis-set defaults.
+
+    When ``treat_missing_as_null`` is ``False``, object slots and mapping
+    keys that are present in ``source`` but absent in ``target`` are
     silently ignored (partial-update semantics). List elements are always
     treated as complete: a shorter target list produces ``remove`` deltas for
     trailing source elements regardless of this flag.

--- a/src/python/src/lib.rs
+++ b/src/python/src/lib.rs
@@ -1462,15 +1462,20 @@ fn load_json(
     signature = (
         source,
         target,
-        treat_missing_as_null = false,
+        treat_missing_as_null,
         treat_changed_identifier_as_new_object = true
     ),
-    text_signature = "(source, target, treat_missing_as_null=False, treat_changed_identifier_as_new_object=True)"
+    text_signature = "(source, target, treat_missing_as_null, treat_changed_identifier_as_new_object=True)"
 )]
 /// Compute deltas between two instances.
 ///
-/// When ``treat_missing_as_null`` is ``False`` (default), object slots and
-/// mapping keys that are present in ``source`` but absent in ``target`` are
+/// ``treat_missing_as_null`` is required — callers must decide explicitly
+/// whether absent entries mean "unchanged" or "removed", since the two
+/// interpretations produce materially different deltas and silent
+/// data-loss bugs have resulted from mis-set defaults.
+///
+/// When ``treat_missing_as_null`` is ``False``, object slots and mapping
+/// keys that are present in ``source`` but absent in ``target`` are
 /// silently ignored (partial-update semantics). List elements are always
 /// treated as complete: a shorter target list produces ``remove`` deltas for
 /// trailing source elements regardless of this flag.

--- a/src/python/tests/python_diff_patch.rs
+++ b/src/python/tests/python_diff_patch.rs
@@ -80,7 +80,7 @@ assert older.schema_view is sv
 assert current.schema_view is sv
 assert_no_errors(older_issues)
 assert_no_errors(current_issues)
-deltas = lr.diff(older, current)
+deltas = lr.diff(older, current, treat_missing_as_null=False)
 assert isinstance(deltas, list)
 for d in deltas:
     assert isinstance(d, lr.Delta)
@@ -128,13 +128,13 @@ assert invalid_container is not None
 assert_no_errors(valid_issues)
 assert any(issue.severity == 'error' for issue in invalid_issues), invalid_issues
 
-deltas_invalid = lr.diff(valid_container, invalid_container)
+deltas_invalid = lr.diff(valid_container, invalid_container, treat_missing_as_null=False)
 assert deltas_invalid
 patched_invalid = lr.patch(valid_container, deltas_invalid)
 assert patched_invalid.trace.failed == []
 assert patched_invalid.value.as_python() == invalid_container.as_python()
 
-deltas_valid = lr.diff(invalid_container, valid_container)
+deltas_valid = lr.diff(invalid_container, valid_container, treat_missing_as_null=False)
 assert deltas_valid
 patched_valid = lr.patch(invalid_container, deltas_valid)
 assert patched_valid.trace.failed == []

--- a/src/runtime/src/blame/mod.rs
+++ b/src/runtime/src/blame/mod.rs
@@ -360,11 +360,7 @@ mod tests {
         .into_instance()
         .unwrap();
 
-        let deltas_stage2 = diff(
-            &value_after_stage1,
-            &stage2,
-            DiffOptions::new(true),
-        );
+        let deltas_stage2 = diff(&value_after_stage1, &stage2, DiffOptions::new(true));
         let (final_value, trace2) = patch_with_blame(
             &value_after_stage1,
             &deltas_stage2,
@@ -444,11 +440,7 @@ mod tests {
         .into_instance()
         .unwrap();
 
-        let deltas_stage2 = diff(
-            &value_after_stage1,
-            &stage2,
-            DiffOptions::new(true),
-        );
+        let deltas_stage2 = diff(&value_after_stage1, &stage2, DiffOptions::new(true));
         assert!(!deltas_stage2.is_empty());
         let (final_value, trace2) = patch_with_blame(
             &value_after_stage1,

--- a/src/runtime/src/blame/mod.rs
+++ b/src/runtime/src/blame/mod.rs
@@ -76,7 +76,7 @@ pub fn blame_map_to_paths<M: Clone>(
         match node {
             LinkMLInstance::Object { values, .. } | LinkMLInstance::Mapping { values, .. } => {
                 let mut entries: Vec<_> = values.iter().collect();
-                entries.sort_by(|(ka, _), (kb, _)| ka.cmp(kb));
+                entries.sort_by_key(|(k, _)| *k);
                 for (key, child) in entries {
                     path.push(key.clone());
                     collect_paths(child, blame, path, out);
@@ -170,7 +170,7 @@ pub fn format_blame_map_with<M>(
                 };
                 lines.push(format!("{meta_str} | {header}"));
                 let mut entries: Vec<_> = values.iter().collect();
-                entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                entries.sort_by_key(|(k, _)| *k);
                 for (child_key, child_value) in entries {
                     walk(
                         child_value,
@@ -192,7 +192,7 @@ pub fn format_blame_map_with<M>(
                 };
                 lines.push(format!("{meta_str} | {header}"));
                 let mut entries: Vec<_> = values.iter().collect();
-                entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                entries.sort_by_key(|(k, _)| *k);
                 for (child_key, child_value) in entries {
                     walk(
                         child_value,

--- a/src/runtime/src/blame/mod.rs
+++ b/src/runtime/src/blame/mod.rs
@@ -333,7 +333,7 @@ mod tests {
         .unwrap()
         .into_instance()
         .unwrap();
-        let deltas_stage1 = diff(&base, &stage1, DiffOptions::default());
+        let deltas_stage1 = diff(&base, &stage1, DiffOptions::new(false));
         let (value_after_stage1, trace1) = patch_with_blame(
             &base,
             &deltas_stage1,
@@ -363,10 +363,7 @@ mod tests {
         let deltas_stage2 = diff(
             &value_after_stage1,
             &stage2,
-            DiffOptions {
-                treat_missing_as_null: true,
-                ..DiffOptions::default()
-            },
+            DiffOptions::new(true),
         );
         let (final_value, trace2) = patch_with_blame(
             &value_after_stage1,
@@ -416,7 +413,7 @@ mod tests {
         .into_instance()
         .unwrap();
 
-        let deltas_stage1 = diff(&base, &stage1, DiffOptions::default());
+        let deltas_stage1 = diff(&base, &stage1, DiffOptions::new(false));
         let (value_after_stage1, trace1) = patch_with_blame(
             &base,
             &deltas_stage1,
@@ -450,10 +447,7 @@ mod tests {
         let deltas_stage2 = diff(
             &value_after_stage1,
             &stage2,
-            DiffOptions {
-                treat_missing_as_null: true,
-                ..DiffOptions::default()
-            },
+            DiffOptions::new(true),
         );
         assert!(!deltas_stage2.is_empty());
         let (final_value, trace2) = patch_with_blame(
@@ -534,7 +528,7 @@ mod tests {
         .into_instance()
         .expect("invalid target");
 
-        let deltas = diff(&base, &target, DiffOptions::default());
+        let deltas = diff(&base, &target, DiffOptions::new(false));
         println!("deltas = {:#?}", deltas);
 
         let mut blame = HashMap::new();

--- a/src/runtime/src/diff.rs
+++ b/src/runtime/src/diff.rs
@@ -78,10 +78,23 @@ pub struct DiffOptions {
     pub treat_changed_identifier_as_new_object: bool,
 }
 
-impl Default for DiffOptions {
-    fn default() -> Self {
+impl DiffOptions {
+    /// Construct with an explicit value for [`DiffOptions::treat_missing_as_null`].
+    ///
+    /// This flag is intentionally required: its effect (partial-update vs
+    /// target-is-authoritative) is easy to misread and was too important to
+    /// hide behind a `Default`. [`DiffOptions::treat_changed_identifier_as_new_object`]
+    /// is set to `true` — override via struct update syntax when needed:
+    ///
+    /// ```ignore
+    /// DiffOptions {
+    ///     treat_changed_identifier_as_new_object: false,
+    ///     ..DiffOptions::new(true)
+    /// }
+    /// ```
+    pub fn new(treat_missing_as_null: bool) -> Self {
         Self {
-            treat_missing_as_null: false,
+            treat_missing_as_null,
             treat_changed_identifier_as_new_object: true,
         }
     }

--- a/src/runtime/tests/diff.rs
+++ b/src/runtime/tests/diff.rs
@@ -79,7 +79,7 @@ fn diff_and_patch_person() {
         &conv,
     );
 
-    let deltas = diff(&src, &tgt, DiffOptions::default());
+    let deltas = diff(&src, &tgt, DiffOptions::new(false));
     assert_eq!(deltas.len(), 1);
     // Ensure delta paths are navigable on respective values
     for d in &deltas {
@@ -128,7 +128,7 @@ fn diff_ignore_missing_target() {
         &conv,
     );
 
-    let deltas = diff(&src, &tgt, DiffOptions::default());
+    let deltas = diff(&src, &tgt, DiffOptions::new(false));
     assert!(deltas.is_empty());
     let (patched, _trace) = patch(
         &src,
@@ -164,7 +164,7 @@ fn diff_and_patch_personinfo() {
         &conv,
     );
 
-    let deltas = diff(&src, &tgt, DiffOptions::default());
+    let deltas = diff(&src, &tgt, DiffOptions::new(false));
     assert!(!deltas.is_empty());
     // Ensure delta paths are navigable on respective values, including mapping-list keys
     for d in &deltas {
@@ -215,7 +215,7 @@ fn diff_null_and_missing_semantics() {
             &class,
             &conv,
         );
-        let deltas = diff(&src, &tgt, DiffOptions::default());
+        let deltas = diff(&src, &tgt, DiffOptions::new(false));
         assert!(deltas
             .iter()
             .any(|d| d.path == vec!["age".to_string()] && d.new == Some(serde_json::Value::Null)));
@@ -233,7 +233,7 @@ fn diff_null_and_missing_semantics() {
             &class,
             &conv,
         );
-        let deltas = diff(&src_with_null, &src, DiffOptions::default());
+        let deltas = diff(&src_with_null, &src, DiffOptions::new(false));
         assert!(deltas.iter().any(|d| d.path == vec!["age".to_string()]
             && d.old == Some(serde_json::Value::Null)
             && d.new.is_some()));
@@ -251,7 +251,7 @@ fn diff_null_and_missing_semantics() {
             &class,
             &conv,
         );
-        let deltas = diff(&src_missing, &src, DiffOptions::default());
+        let deltas = diff(&src_missing, &src, DiffOptions::new(false));
         assert!(deltas
             .iter()
             .any(|d| d.path == vec!["age".to_string()] && d.old.is_none() && d.new.is_some()));
@@ -269,16 +269,9 @@ fn diff_null_and_missing_semantics() {
             &class,
             &conv,
         );
-        let deltas = diff(&src, &tgt_missing, DiffOptions::default());
+        let deltas = diff(&src, &tgt_missing, DiffOptions::new(false));
         assert!(deltas.iter().all(|d| d.path != vec!["age".to_string()]));
-        let deltas2 = diff(
-            &src,
-            &tgt_missing,
-            DiffOptions {
-                treat_missing_as_null: true,
-                ..DiffOptions::default()
-            },
-        );
+        let deltas2 = diff(&src, &tgt_missing, DiffOptions::new(true));
         assert!(deltas2
             .iter()
             .any(|d| d.path == vec!["age".to_string()] && d.new == Some(serde_json::Value::Null)))
@@ -330,7 +323,7 @@ fn diff_and_patch_tolerate_validation_errors() {
         &container,
         &conv,
     );
-    let deltas = diff(&invalid_instance, &valid_instance, DiffOptions::default());
+    let deltas = diff(&invalid_instance, &valid_instance, DiffOptions::new(false));
     assert!(!deltas.is_empty());
     let (patched, _trace) = patch(
         &invalid_instance,
@@ -368,7 +361,7 @@ fn diff_and_patch_invalid_target() {
     let invalid_instance = invalid_result
         .into_instance_tolerate_errors()
         .expect("instance should still be returned");
-    let deltas = diff(&valid_instance, &invalid_instance, DiffOptions::default());
+    let deltas = diff(&valid_instance, &invalid_instance, DiffOptions::new(false));
     assert!(!deltas.is_empty());
     let (patched, _trace) = patch(
         &valid_instance,
@@ -422,21 +415,14 @@ fn diff_mapping_ignore_missing_target() {
     );
 
     // Default: treat_missing_as_null=false → no Remove for "mother"
-    let deltas = diff(&source, &target, DiffOptions::default());
+    let deltas = diff(&source, &target, DiffOptions::new(false));
     assert!(
         !deltas.iter().any(|d| d.op == DeltaOp::Remove),
         "expected no Remove deltas with treat_missing_as_null=false, got: {deltas:?}"
     );
 
     // With treat_missing_as_null=true → should produce a Remove for "mother"
-    let deltas_strict = diff(
-        &source,
-        &target,
-        DiffOptions {
-            treat_missing_as_null: true,
-            ..DiffOptions::default()
-        },
-    );
+    let deltas_strict = diff(&source, &target, DiffOptions::new(true));
     assert!(
         deltas_strict.iter().any(|d| d.op == DeltaOp::Remove
             && d.path
@@ -469,7 +455,7 @@ fn diff_and_patch_multiple_removes_from_scalar_list() {
         &conv,
     );
 
-    let deltas = diff(&src, &tgt, DiffOptions::default());
+    let deltas = diff(&src, &tgt, DiffOptions::new(false));
     let remove_count = deltas.iter().filter(|d| d.op == DeltaOp::Remove).count();
     assert_eq!(
         remove_count, 3,

--- a/src/runtime/tests/diff_identifier.rs
+++ b/src/runtime/tests/diff_identifier.rs
@@ -82,7 +82,7 @@ fn single_inlined_object_identifier_change_is_replacement() {
         &conv,
     );
 
-    let deltas_default = diff(&src, &tgt, DiffOptions::default());
+    let deltas_default = diff(&src, &tgt, DiffOptions::new(false));
     // Expect a single replacement at the diagnosis object path with default behaviour
     assert_eq!(deltas_default.len(), 1);
     let d = &deltas_default[0];
@@ -116,7 +116,7 @@ fn single_inlined_object_identifier_change_is_replacement() {
         &tgt,
         DiffOptions {
             treat_changed_identifier_as_new_object: false,
-            ..DiffOptions::default()
+            ..DiffOptions::new(false)
         },
     );
     assert_eq!(deltas_plain.len(), 1);
@@ -189,7 +189,7 @@ fn single_inlined_object_non_identifier_change_is_field_delta() {
         &conv,
     );
 
-    let deltas = diff(&src, &tgt, DiffOptions::default());
+    let deltas = diff(&src, &tgt, DiffOptions::new(false));
     assert!(deltas.iter().any(|d| d.path
         == vec![
             "objects".to_string(),
@@ -255,7 +255,7 @@ fn list_inlined_object_identifier_change_is_replacement() {
         &conv,
     );
 
-    let deltas = diff(&src, &tgt, DiffOptions::default());
+    let deltas = diff(&src, &tgt, DiffOptions::new(false));
     // Expect a single replacement at the list item path
     assert!(deltas.iter().any(|d| {
         d.path == vec!["objects".to_string(), "P:002".to_string()]
@@ -314,10 +314,7 @@ fn mapping_inlined_identifier_change_is_add_delete() {
     let deltas = diff(
         &src,
         &tgt,
-        DiffOptions {
-            treat_missing_as_null: true,
-            ..DiffOptions::default()
-        },
+        DiffOptions::new(true),
     );
     // Expect one delete and one add at mapping keys; no inner key-slot deltas
     assert!(deltas

--- a/src/runtime/tests/diff_identifier.rs
+++ b/src/runtime/tests/diff_identifier.rs
@@ -311,11 +311,7 @@ fn mapping_inlined_identifier_change_is_add_delete() {
     let tgt = load_json_instance(&serde_json::to_string(&tgt_json).unwrap(), &sv, &bag, &conv);
 
     // With treat_missing_as_null=true, renaming a mapping key produces delete + add.
-    let deltas = diff(
-        &src,
-        &tgt,
-        DiffOptions::new(true),
-    );
+    let deltas = diff(&src, &tgt, DiffOptions::new(true));
     // Expect one delete and one add at mapping keys; no inner key-slot deltas
     assert!(deltas
         .iter()

--- a/src/runtime/tests/trace.rs
+++ b/src/runtime/tests/trace.rs
@@ -83,7 +83,7 @@ fn node_ids_preserved_scalar_update() {
     .into_instance()
     .unwrap();
 
-    let deltas = diff(&src, &tgt, DiffOptions::default());
+    let deltas = diff(&src, &tgt, DiffOptions::new(false));
     let (patched, trace) = linkml_runtime::patch(
         &src,
         &deltas,
@@ -143,7 +143,7 @@ fn patch_trace_add_in_list() {
     .into_instance()
     .unwrap();
 
-    let deltas = diff(&base, &target, DiffOptions::default());
+    let deltas = diff(&base, &target, DiffOptions::new(false));
     let mut pre = Vec::new();
     collect_ids(&base, &mut pre);
     let (patched, trace) = linkml_runtime::patch(

--- a/src/tools/src/bin/linkml_diff.rs
+++ b/src/tools/src/bin/linkml_diff.rs
@@ -26,6 +26,12 @@ struct Args {
     /// Output file for deltas; defaults to stdout
     #[arg(short, long)]
     output: Option<PathBuf>,
+    /// Whether entries present in source but absent in target are treated
+    /// as explicit removals (`true`) or silently ignored as partial
+    /// updates (`false`). Required — no default is provided because the
+    /// two interpretations produce materially different deltas.
+    #[arg(long, value_name = "BOOL", action = clap::ArgAction::Set)]
+    treat_missing_as_null: bool,
 }
 
 fn load_value(
@@ -67,7 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let src = load_value(&args.source, &sv, &class_view, &conv)?;
     let tgt = load_value(&args.target, &sv, &class_view, &conv)?;
-    let deltas = diff(&src, &tgt, DiffOptions::default());
+    let deltas = diff(&src, &tgt, DiffOptions::new(args.treat_missing_as_null));
 
     let mut writer: Box<dyn Write> = if let Some(out) = &args.output {
         Box::new(File::create(out)?)

--- a/src/tools/tests/diff_cli.rs
+++ b/src/tools/tests/diff_cli.rs
@@ -24,7 +24,9 @@ fn cli_diff_and_patch_personinfo() {
         .arg(&src)
         .arg(&tgt)
         .arg("-o")
-        .arg(&delta);
+        .arg(&delta)
+        .arg("--treat-missing-as-null")
+        .arg("false");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("linkml-patch").unwrap();


### PR DESCRIPTION
## Summary
- Drop the `Default` impl for `DiffOptions` and the Python-side default for `treat_missing_as_null`. The flag's two interpretations (partial-update vs. target-is-authoritative) produce materially different deltas, and a mis-set default has been the source of silent-data-loss bugs.
- Add `DiffOptions::new(treat_missing_as_null: bool)` which keeps `treat_changed_identifier_as_new_object: true` inside the constructor; the rare override uses `..DiffOptions::new(..)`.
- `linkml-diff` CLI gains a required `--treat-missing-as-null <BOOL>` flag with no default.

## Breaking changes
- **Rust**: `DiffOptions::default()` no longer exists. Replace with `DiffOptions::new(false)` (previous default) or `DiffOptions::new(true)` after deciding which semantics you actually want.
- **Python**: `lr.diff(source, target)` now raises `TypeError`. Pass `treat_missing_as_null=False` (partial-update) or `True` (target-is-authoritative) explicitly. Downstream callers in `consolidator-server` will need updating.
- **CLI**: `linkml-diff` requires `--treat-missing-as-null true|false`.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all tests pass (including the Python roundtrip and the CLI integration test, both updated to pass the explicit argument)
- [x] Manual smoke test with `linkml-diff --treat-missing-as-null false ...` on reviewer's machine
- [ ] Audit `consolidator-server` and any other downstream Python consumers for `lr.diff(...)` call sites and update them before the next binding release

🤖 Generated with [Claude Code](https://claude.com/claude-code)