### PR TITLE
fix(metamodel): preserve explicit tag/extension_tag in annotation deserialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ members = [
 [tool.black]
 line-length = 100
 target-version = ["py38", "py39", "py310", "py311", "py312"]
-include = "\.(py|pyi)$"
+include = "\\.(py|pyi)$"
 
 [tool.ruff]
 line-length = 100

--- a/src/metamodel/src/lib.rs
+++ b/src/metamodel/src/lib.rs
@@ -733,7 +733,11 @@ impl serde_utils::InlinedPair for Extension {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("extension_tag".into()), Value::String(k));
+        if !map.contains_key(&Value::String("extension_tag".into()))
+            && !map.contains_key(&Value::String("tag".into()))
+        {
+            map.insert(Value::String("extension_tag".into()), Value::String(k));
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -1704,7 +1708,11 @@ impl serde_utils::InlinedPair for Annotation {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("extension_tag".into()), Value::String(k));
+        if !map.contains_key(&Value::String("extension_tag".into()))
+            && !map.contains_key(&Value::String("tag".into()))
+        {
+            map.insert(Value::String("extension_tag".into()), Value::String(k));
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -1721,6 +1729,44 @@ impl serde_utils::InlinedPair for Annotation {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
         }
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod annotation_deserialization_tests {
+    use super::*;
+
+    #[test]
+    fn inlined_annotation_accepts_explicit_tag_alias() {
+        let mut map = BTreeMap::new();
+        map.insert(Value::String("tag".into()), Value::String("foo".into()));
+        map.insert(Value::String("value".into()), Value::String("bar".into()));
+
+        let annotation = <Annotation as serde_utils::InlinedPair>::from_pair_mapping(
+            "foo".into(),
+            Value::Map(map),
+        )
+        .expect("annotation with explicit tag alias should deserialize");
+
+        assert_eq!(annotation.extension_tag, "foo");
+    }
+
+    #[test]
+    fn inlined_annotation_accepts_explicit_extension_tag() {
+        let mut map = BTreeMap::new();
+        map.insert(
+            Value::String("extension_tag".into()),
+            Value::String("foo".into()),
+        );
+        map.insert(Value::String("value".into()), Value::String("bar".into()));
+
+        let annotation = <Annotation as serde_utils::InlinedPair>::from_pair_mapping(
+            "foo".into(),
+            Value::Map(map),
+        )
+        .expect("annotation with explicit extension_tag should deserialize");
+
+        assert_eq!(annotation.extension_tag, "foo");
     }
 }
 


### PR DESCRIPTION
## Problem

`Extension` and `Annotation` both implement `serde_utils::InlinedPair::from_pair_mapping`. The current implementation unconditionally inserts an inferred `extension_tag` key into the deserialization map, regardless of whether the incoming data already contains an explicit `tag:` or `extension_tag:` field.

This causes a deserialization failure for any LinkML schema that carries explicit annotation tags — a common pattern in real-world schemas (e.g. the core LinkML metamodel itself). The only workaround was a Python pre-pass to strip annotations before handing the schema to the Rust backend.

## Fix

Guard the `map.insert` call: only inject the inferred `extension_tag` when neither `extension_tag` nor `tag` is already present in the map.

```rust
if !map.contains_key(&Value::String("extension_tag".into()))
    && !map.contains_key(&Value::String("tag".into()))
{
    map.insert(Value::String("extension_tag".into()), Value::String(k));
}
```

Applied to both `Extension::from_pair_mapping` and `Annotation::from_pair_mapping`.

## Tests

Two new unit tests added in `annotation_deserialization_tests`:

- `inlined_annotation_accepts_explicit_tag_alias` — explicit `tag:` field round-trips correctly
- `inlined_annotation_accepts_explicit_extension_tag` — explicit `extension_tag:` field round-trips correctly

Run with:
```
cargo test -p linkml_meta annotation_deserialization_tests --features serde
```

## Bonus fix

`pyproject.toml` contained an invalid TOML escape sequence (`"\."`) in the `[tool.black]` include pattern. Python 3.11+ `tomllib` raises `TOMLDecodeError` for unknown escape sequences, breaking `black`, `mypy`, and any other tool that reads the config. Fixed to `"\."` (correct TOML for a literal backslash-dot).