### PR TITLE
chore(metamodel): refresh bundled linkml metamodel to 1.11.0 and fix default-URI indexing

### DIFF
--- a/src/metamodel/src/bin/stub_gen.rs
+++ b/src/metamodel/src/bin/stub_gen.rs
@@ -1,4 +1,7 @@
 #[cfg(feature = "stubgen")]
+use linkml_meta::stub_utils;
+
+#[cfg(feature = "stubgen")]
 fn main() -> pyo3_stub_gen::Result<()> {
     let check_only = std::env::args().skip(1).any(|arg| arg == "--check");
     let stub = linkml_meta::stub_info()?;
@@ -18,13 +21,13 @@ fn check_stubs(stub: &pyo3_stub_gen::StubInfo) -> pyo3_stub_gen::Result<()> {
     let mut issues = Vec::new();
 
     for (name, module) in &stub.modules {
-        let normalized_name = name.replace('-', "_");
-        let path = normalized_name.replace('.', "/");
-        let dest = if module.submodules.is_empty() {
-            stub.python_root.join(format!("{path}.pyi"))
+        let module_path = stub_utils::normalize_stub_module(name)?;
+        let mut dest = stub.python_root.join(&module_path);
+        if module.submodules.is_empty() {
+            dest.set_extension("pyi");
         } else {
-            stub.python_root.join(&path).join("__init__.pyi")
-        };
+            dest.push("__init__.pyi");
+        }
 
         let expected = module.to_string();
         match fs::read_to_string(&dest) {

--- a/src/metamodel/src/lib.rs
+++ b/src/metamodel/src/lib.rs
@@ -4,6 +4,8 @@ pub mod poly;
 pub mod poly_containers;
 #[cfg(feature = "serde")]
 mod serde_utils;
+#[cfg(feature = "stubgen")]
+pub mod stub_utils;
 
 use chrono::NaiveDateTime;
 use merge::Merge;
@@ -177,6 +179,8 @@ pub type unique_key_name = String;
 pub type consider_nulls_inequal = bool;
 pub type unique_key_slots = Vec<SlotDefinition>;
 pub type slot_names_unique = bool;
+pub type extra_slots = ExtraSlotsExpression;
+pub type allowed = bool;
 pub type domain = ClassDefinition;
 pub type range = Element;
 pub type slot_uri = uriorcurie;
@@ -670,7 +674,10 @@ pub struct Extension {
     pub extension_value: AnyValue,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, Box<ExtensionOrSubtype>>>,
@@ -733,7 +740,16 @@ impl serde_utils::InlinedPair for Extension {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("extension_tag".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("extension_tag".into()))
+            || map.contains_key(&Value::String("tag".into()));
+        if !already_keyed {
+            map.insert(Value::String("extension_tag".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -743,12 +759,32 @@ impl serde_utils::InlinedPair for Extension {
 
     fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("extension_tag".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("extension_tag".into()), key_value);
         map.insert(Value::String("extension_value".into()), v);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        Some(&self.extension_value)
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("extension_tag".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -814,7 +850,7 @@ impl<'py> FromPyObject<'py> for Box<ExtensionOrSubtype> {
 
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for ExtensionOrSubtype {
-    type Key = String;
+    type Key = uriorcurie;
     type Value = serde_value::Value;
     type Error = String;
 
@@ -849,7 +885,10 @@ impl serde_utils::InlinedPair for ExtensionOrSubtype {
 pub struct Extensible {
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
@@ -1231,7 +1270,10 @@ impl<'py> FromPyObject<'py> for Box<ExtensibleOrSubtype> {
 pub struct Annotatable {
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -1628,7 +1670,10 @@ impl<'py> FromPyObject<'py> for Box<AnnotatableOrSubtype> {
 pub struct Annotation {
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Box<Annotation>>>,
@@ -1638,7 +1683,10 @@ pub struct Annotation {
     pub extension_value: AnyValue,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
@@ -1704,7 +1752,16 @@ impl serde_utils::InlinedPair for Annotation {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("extension_tag".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("extension_tag".into()))
+            || map.contains_key(&Value::String("tag".into()));
+        if !already_keyed {
+            map.insert(Value::String("extension_tag".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -1714,12 +1771,32 @@ impl serde_utils::InlinedPair for Annotation {
 
     fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("extension_tag".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("extension_tag".into()), key_value);
         map.insert(Value::String("extension_value".into()), v);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        Some(&self.extension_value)
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("extension_tag".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -1738,7 +1815,8 @@ pub struct UnitOfMeasure {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -1848,18 +1926,12 @@ impl<'py> FromPyObject<'py> for Anything {
                 return Ok(Value::Unit);
             }
 
-            // Try simple primitives first (bool before int — Python bool is a subclass of int)
-            if let Ok(b) = o.extract::<bool>() {
-                return Ok(Value::Bool(b));
-            }
-            if let Ok(i) = o.extract::<i64>() {
-                return Ok(Value::I64(i));
-            }
-            if let Ok(f) = o.extract::<f64>() {
-                return Ok(Value::F64(f));
-            }
+            // Try simple primitives first
             if let Ok(s) = o.extract::<&str>() {
                 return Ok(Value::String(s.to_string()));
+            }
+            if let Ok(b) = o.extract::<bool>() {
+                return Ok(Value::Bool(b));
             }
 
             // Sequences (list/tuple)
@@ -1936,23 +2008,14 @@ impl<'py> IntoPyObject<'py> for Anything {
                     }
                     Ok(dict.into_any())
                 }
-                Value::U8(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::U16(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::U32(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::U64(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::I8(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::I16(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::I32(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::I64(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::F32(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::F64(n) => Ok(n.into_pyobject(py)?.into_any()),
-                Value::Char(c) => Ok(PyString::new(py, &c.to_string()).into_any()),
-                Value::Option(opt) => match opt {
-                    Some(inner) => value_to_py(py, inner),
-                    None => Ok(py.None().into_bound(py)),
-                },
-                Value::Newtype(inner) => value_to_py(py, inner),
-                Value::Bytes(b) => Ok(pyo3::types::PyBytes::new(py, b).into_any()),
+                // Best-effort for other serde_value variants
+                // (numbers, bytes, chars, etc.)
+                other => {
+                    // Try common cases without bringing extra deps
+                    // Numbers are converted via string if not covered above
+                    let s = format!("{:?}", other);
+                    Ok(PyString::new(py, &s).into_any())
+                }
             }
         }
 
@@ -1978,7 +2041,10 @@ pub struct CommonMetadata {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -1989,7 +2055,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -1997,7 +2064,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2005,7 +2073,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2025,7 +2094,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2037,7 +2107,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2047,7 +2118,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2055,7 +2127,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2063,7 +2136,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2071,7 +2145,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2079,7 +2154,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2087,7 +2163,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2097,7 +2174,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2115,7 +2193,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2123,7 +2202,8 @@ pub struct CommonMetadata {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2650,7 +2730,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2661,7 +2742,10 @@ pub struct Element {
     pub definition_uri: Option<uriorcurie>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub local_names: Option<HashMap<String, LocalName>>,
@@ -2670,7 +2754,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2678,20 +2763,27 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub instantiates: Option<Vec<uriorcurie>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -2699,7 +2791,10 @@ pub struct Element {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -2710,7 +2805,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2718,7 +2814,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2726,7 +2823,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2746,7 +2844,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2758,7 +2857,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2768,7 +2868,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2776,7 +2877,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2784,7 +2886,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2792,7 +2895,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2800,7 +2904,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2808,7 +2913,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2818,7 +2924,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2836,7 +2943,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2844,7 +2952,8 @@ pub struct Element {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -2980,7 +3089,7 @@ impl<'py> FromPyObject<'py> for Box<Element> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for Element {
     type Key = String;
-    type Value = bool;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -2992,7 +3101,15 @@ impl serde_utils::InlinedPair for Element {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("name".into()));
+        if !already_keyed {
+            map.insert(Value::String("name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -3000,14 +3117,29 @@ impl serde_utils::InlinedPair for Element {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("name".into()), Value::String(k));
-        map.insert(Value::String("id_prefixes_are_closed".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("name".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -3234,7 +3366,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3243,14 +3376,18 @@ pub struct SchemaDefinition {
     pub license: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub prefixes: Option<HashMap<String, Prefix>>,
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3258,7 +3395,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3269,32 +3407,47 @@ pub struct SchemaDefinition {
     pub default_range: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub subsets: Option<HashMap<String, SubsetDefinition>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub types: Option<HashMap<String, TypeDefinition>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub enums: Option<HashMap<String, EnumDefinition>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(alias = "slots"))]
     pub slot_definitions: Option<HashMap<String, SlotDefinition>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub classes: Option<HashMap<String, ClassDefinition>>,
@@ -3312,7 +3465,10 @@ pub struct SchemaDefinition {
     pub slot_names_unique: Option<bool>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub settings: Option<HashMap<String, Setting>>,
@@ -3322,7 +3478,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3333,7 +3490,10 @@ pub struct SchemaDefinition {
     pub definition_uri: Option<uriorcurie>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub local_names: Option<HashMap<String, LocalName>>,
@@ -3342,7 +3502,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3350,20 +3511,27 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub instantiates: Option<Vec<uriorcurie>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -3371,7 +3539,10 @@ pub struct SchemaDefinition {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -3382,7 +3553,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3390,7 +3562,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3398,7 +3571,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3418,7 +3592,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3430,7 +3605,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3440,7 +3616,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3448,7 +3625,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3456,7 +3634,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3464,7 +3643,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3472,7 +3652,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3480,7 +3661,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3490,7 +3672,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3508,7 +3691,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3516,7 +3700,8 @@ pub struct SchemaDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3716,7 +3901,15 @@ impl serde_utils::InlinedPair for SchemaDefinition {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("name".into()));
+        if !already_keyed {
+            map.insert(Value::String("name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -3726,12 +3919,32 @@ impl serde_utils::InlinedPair for SchemaDefinition {
 
     fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("name".into()), key_value);
         map.insert(Value::String("id".into()), v);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        Some(&self.id)
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -3754,7 +3967,8 @@ pub struct AnonymousTypeExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3849,7 +4063,6 @@ impl<'py> FromPyObject<'py> for Box<AnonymousTypeExpression> {
 #[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
 pub struct TypeDefinition {
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "serde", serde(alias = "typeof"))]
     pub typeof_: Option<String>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub base: Option<String>,
@@ -3873,7 +4086,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3896,7 +4110,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3907,7 +4122,10 @@ pub struct TypeDefinition {
     pub definition_uri: Option<uriorcurie>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub local_names: Option<HashMap<String, LocalName>>,
@@ -3916,7 +4134,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3924,20 +4143,27 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub instantiates: Option<Vec<uriorcurie>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -3945,7 +4171,10 @@ pub struct TypeDefinition {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -3956,7 +4185,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3964,7 +4194,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3972,7 +4203,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -3992,7 +4224,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4004,7 +4237,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4014,7 +4248,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4022,7 +4257,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4030,7 +4266,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4038,7 +4275,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4046,7 +4284,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4054,7 +4293,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4064,7 +4304,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4082,7 +4323,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4090,7 +4332,8 @@ pub struct TypeDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4270,7 +4513,7 @@ impl<'py> FromPyObject<'py> for Box<TypeDefinition> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for TypeDefinition {
     type Key = String;
-    type Value = TypeDefinition;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -4282,7 +4525,15 @@ impl serde_utils::InlinedPair for TypeDefinition {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("name".into()));
+        if !already_keyed {
+            map.insert(Value::String("name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -4290,14 +4541,29 @@ impl serde_utils::InlinedPair for TypeDefinition {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("name".into()), Value::String(k));
-        map.insert(Value::String("typeof_".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("name".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -4311,7 +4577,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4322,7 +4589,10 @@ pub struct SubsetDefinition {
     pub definition_uri: Option<uriorcurie>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub local_names: Option<HashMap<String, LocalName>>,
@@ -4331,7 +4601,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4339,20 +4610,27 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub instantiates: Option<Vec<uriorcurie>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -4360,7 +4638,10 @@ pub struct SubsetDefinition {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -4371,7 +4652,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4379,7 +4661,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4387,7 +4670,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4407,7 +4691,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4419,7 +4704,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4429,7 +4715,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4437,7 +4724,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4445,7 +4733,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4453,7 +4742,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4461,7 +4751,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4469,7 +4760,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4479,7 +4771,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4497,7 +4790,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4505,7 +4799,8 @@ pub struct SubsetDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4641,7 +4936,7 @@ impl<'py> FromPyObject<'py> for Box<SubsetDefinition> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for SubsetDefinition {
     type Key = String;
-    type Value = bool;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -4653,7 +4948,15 @@ impl serde_utils::InlinedPair for SubsetDefinition {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("name".into()));
+        if !already_keyed {
+            map.insert(Value::String("name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -4661,14 +4964,29 @@ impl serde_utils::InlinedPair for SubsetDefinition {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("name".into()), Value::String(k));
-        map.insert(Value::String("id_prefixes_are_closed".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("name".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -4900,7 +5218,6 @@ pub struct Definition {
     #[cfg_attr(feature = "serde", serde(default))]
     pub is_a: Option<String>,
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "serde", serde(alias = "abstract"))]
     pub abstract_: Option<bool>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub mixin: Option<bool>,
@@ -4911,7 +5228,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4922,7 +5240,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4933,7 +5252,10 @@ pub struct Definition {
     pub definition_uri: Option<uriorcurie>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub local_names: Option<HashMap<String, LocalName>>,
@@ -4942,7 +5264,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4950,20 +5273,27 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub instantiates: Option<Vec<uriorcurie>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -4971,7 +5301,10 @@ pub struct Definition {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -4982,7 +5315,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4990,7 +5324,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -4998,7 +5333,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5018,7 +5354,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5030,7 +5367,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5040,7 +5378,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5048,7 +5387,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5056,7 +5396,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5064,7 +5405,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5072,7 +5414,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5080,7 +5423,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5090,7 +5434,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5108,7 +5453,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5116,7 +5462,8 @@ pub struct Definition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5266,7 +5613,7 @@ impl<'py> FromPyObject<'py> for Box<Definition> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for Definition {
     type Key = String;
-    type Value = Definition;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -5278,7 +5625,15 @@ impl serde_utils::InlinedPair for Definition {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("name".into()));
+        if !already_keyed {
+            map.insert(Value::String("name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -5286,14 +5641,29 @@ impl serde_utils::InlinedPair for Definition {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("name".into()), Value::String(k));
-        map.insert(Value::String("is_a".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("name".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -5444,7 +5814,10 @@ pub struct AnonymousEnumExpression {
     pub pv_formula: Option<PvFormulaOptions>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub permissible_values: Option<HashMap<String, PermissibleValue>>,
@@ -5461,7 +5834,8 @@ pub struct AnonymousEnumExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5546,7 +5920,10 @@ pub struct EnumDefinition {
     pub pv_formula: Option<PvFormulaOptions>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub permissible_values: Option<HashMap<String, PermissibleValue>>,
@@ -5563,7 +5940,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5571,7 +5949,6 @@ pub struct EnumDefinition {
     #[cfg_attr(feature = "serde", serde(default))]
     pub is_a: Option<String>,
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "serde", serde(alias = "abstract"))]
     pub abstract_: Option<bool>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub mixin: Option<bool>,
@@ -5582,7 +5959,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5593,7 +5971,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5604,7 +5983,10 @@ pub struct EnumDefinition {
     pub definition_uri: Option<uriorcurie>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub local_names: Option<HashMap<String, LocalName>>,
@@ -5613,7 +5995,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5621,20 +6004,27 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub instantiates: Option<Vec<uriorcurie>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -5642,7 +6032,10 @@ pub struct EnumDefinition {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -5653,7 +6046,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5661,7 +6055,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5669,7 +6064,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5689,7 +6085,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5701,7 +6098,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5711,7 +6109,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5719,7 +6118,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5727,7 +6127,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5735,7 +6136,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5743,7 +6145,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5751,7 +6154,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5761,7 +6165,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5779,7 +6184,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5787,7 +6193,8 @@ pub struct EnumDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -5966,7 +6373,7 @@ impl<'py> FromPyObject<'py> for Box<EnumDefinition> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for EnumDefinition {
     type Key = String;
-    type Value = uriorcurie;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -5978,7 +6385,15 @@ impl serde_utils::InlinedPair for EnumDefinition {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("name".into()));
+        if !already_keyed {
+            map.insert(Value::String("name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -5986,14 +6401,29 @@ impl serde_utils::InlinedPair for EnumDefinition {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("name".into()), Value::String(k));
-        map.insert(Value::String("enum_uri".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("name".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -6013,13 +6443,19 @@ pub struct EnumBinding {
     pub pv_formula: Option<PvFormulaOptions>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -6027,7 +6463,10 @@ pub struct EnumBinding {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -6038,7 +6477,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6046,7 +6486,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6054,7 +6495,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6074,7 +6516,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6086,7 +6529,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6096,7 +6540,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6104,7 +6549,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6112,7 +6558,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6120,7 +6567,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6128,7 +6576,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6136,7 +6585,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6146,7 +6596,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6164,7 +6615,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6172,7 +6624,8 @@ pub struct EnumBinding {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6352,7 +6805,8 @@ pub struct ReachabilityQuery {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6360,7 +6814,8 @@ pub struct ReachabilityQuery {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6431,7 +6886,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6439,7 +6895,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6447,13 +6904,19 @@ pub struct StructuredAlias {
     pub alias_contexts: Option<Vec<uri>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -6461,7 +6924,10 @@ pub struct StructuredAlias {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -6472,7 +6938,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6480,7 +6947,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6488,7 +6956,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6508,7 +6977,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6520,7 +6990,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6530,7 +7001,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6538,7 +7010,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6546,7 +7019,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6554,7 +7028,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6562,7 +7037,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6570,7 +7046,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6580,7 +7057,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6598,7 +7076,8 @@ pub struct StructuredAlias {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -6735,6 +7214,7 @@ pub enum ExpressionOrSubtype {
     AnonymousExpression(AnonymousExpression),
     PathExpression(PathExpression),
     SlotExpression(SlotExpression),
+    ExtraSlotsExpression(ExtraSlotsExpression),
     AnonymousSlotExpression(AnonymousSlotExpression),
     SlotDefinition(SlotDefinition),
     AnonymousClassExpression(AnonymousClassExpression),
@@ -6772,6 +7252,11 @@ impl From<PathExpression> for ExpressionOrSubtype {
 impl From<SlotExpression> for ExpressionOrSubtype {
     fn from(x: SlotExpression) -> Self {
         Self::SlotExpression(x)
+    }
+}
+impl From<ExtraSlotsExpression> for ExpressionOrSubtype {
+    fn from(x: ExtraSlotsExpression) -> Self {
+        Self::ExtraSlotsExpression(x)
     }
 }
 impl From<AnonymousSlotExpression> for ExpressionOrSubtype {
@@ -6831,6 +7316,9 @@ impl<'py> FromPyObject<'py> for ExpressionOrSubtype {
         if let Ok(val) = ob.extract::<SlotExpression>() {
             return Ok(ExpressionOrSubtype::SlotExpression(val));
         }
+        if let Ok(val) = ob.extract::<ExtraSlotsExpression>() {
+            return Ok(ExpressionOrSubtype::ExtraSlotsExpression(val));
+        }
         if let Ok(val) = ob.extract::<AnonymousSlotExpression>() {
             return Ok(ExpressionOrSubtype::AnonymousSlotExpression(val));
         }
@@ -6882,6 +7370,9 @@ impl<'py> IntoPyObject<'py> for ExpressionOrSubtype {
                 val.into_pyobject(py).map(move |b| b.into_any())
             }
             ExpressionOrSubtype::SlotExpression(val) => {
+                val.into_pyobject(py).map(move |b| b.into_any())
+            }
+            ExpressionOrSubtype::ExtraSlotsExpression(val) => {
                 val.into_pyobject(py).map(move |b| b.into_any())
             }
             ExpressionOrSubtype::AnonymousSlotExpression(val) => {
@@ -6939,6 +7430,7 @@ impl<'py> FromPyObject<'py> for Box<ExpressionOrSubtype> {
         | AnonymousExpression
         | PathExpression
         | SlotExpression
+        | ExtraSlotsExpression
         | AnonymousSlotExpression
         | SlotDefinition
         | AnonymousClassExpression
@@ -6966,7 +7458,8 @@ pub struct TypeExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7149,7 +7642,10 @@ pub struct EnumExpression {
     pub pv_formula: Option<PvFormulaOptions>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub permissible_values: Option<HashMap<String, PermissibleValue>>,
@@ -7166,7 +7662,8 @@ pub struct EnumExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7320,13 +7817,19 @@ impl<'py> FromPyObject<'py> for Box<EnumExpressionOrSubtype> {
 pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -7334,7 +7837,10 @@ pub struct AnonymousExpression {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -7345,7 +7851,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7353,7 +7860,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7361,7 +7869,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7381,7 +7890,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7393,7 +7903,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7403,7 +7914,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7411,7 +7923,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7419,7 +7932,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7427,7 +7941,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7435,7 +7950,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7443,7 +7959,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7453,7 +7970,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7471,7 +7989,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7479,7 +7998,8 @@ pub struct AnonymousExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7697,13 +8217,19 @@ pub struct PathExpression {
     pub range_expression: Option<Box<AnonymousClassExpression>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -7711,7 +8237,10 @@ pub struct PathExpression {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -7722,7 +8251,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7730,7 +8260,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7738,7 +8269,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7758,7 +8290,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7770,7 +8303,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7780,7 +8314,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7788,7 +8323,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7796,7 +8332,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7804,7 +8341,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7812,7 +8350,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7820,7 +8359,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7830,7 +8370,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7848,7 +8389,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -7856,7 +8398,8 @@ pub struct PathExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8036,7 +8579,8 @@ pub struct SlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8063,13 +8607,15 @@ pub struct SlotExpression {
     pub any_of: Option<Vec<AnonymousSlotExpression>>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub all_of: Option<Vec<AnonymousSlotExpression>>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub array: Option<ArrayExpression>,
 }
 #[cfg(feature = "pyo3")]
 #[cfg_attr(feature = "stubgen", gen_stub_pymethods)]
 #[pymethods]
 impl SlotExpression {
     #[new]
-    #[pyo3(signature = (range=None, range_expression=None, enum_range=None, bindings=None, required=None, recommended=None, multivalued=None, inlined=None, inlined_as_list=None, minimum_value=None, maximum_value=None, pattern=None, structured_pattern=None, unit=None, implicit_prefix=None, value_presence=None, equals_string=None, equals_string_in=None, equals_number=None, equals_expression=None, exact_cardinality=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members=None, none_of=None, exactly_one_of=None, any_of=None, all_of=None))]
+    #[pyo3(signature = (range=None, range_expression=None, enum_range=None, bindings=None, required=None, recommended=None, multivalued=None, inlined=None, inlined_as_list=None, minimum_value=None, maximum_value=None, pattern=None, structured_pattern=None, unit=None, implicit_prefix=None, value_presence=None, equals_string=None, equals_string_in=None, equals_number=None, equals_expression=None, exact_cardinality=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members=None, none_of=None, exactly_one_of=None, any_of=None, all_of=None, array=None))]
     pub fn new(
         range: Option<String>,
         range_expression: Option<serde_utils::PyValue<AnonymousClassExpression>>,
@@ -8100,6 +8646,7 @@ impl SlotExpression {
         exactly_one_of: Option<serde_utils::PyValue<Vec<AnonymousSlotExpression>>>,
         any_of: Option<serde_utils::PyValue<Vec<AnonymousSlotExpression>>>,
         all_of: Option<serde_utils::PyValue<Vec<AnonymousSlotExpression>>>,
+        array: Option<serde_utils::PyValue<ArrayExpression>>,
     ) -> Self {
         let range_expression = range_expression.map(|v| v.into_inner());
         let enum_range = enum_range.map(|v| v.into_inner());
@@ -8114,6 +8661,7 @@ impl SlotExpression {
         let exactly_one_of = exactly_one_of.map(|v| v.into_inner());
         let any_of = any_of.map(|v| v.into_inner());
         let all_of = all_of.map(|v| v.into_inner());
+        let array = array.map(|v| v.into_inner());
         SlotExpression {
             range,
             range_expression,
@@ -8144,6 +8692,7 @@ impl SlotExpression {
             exactly_one_of,
             any_of,
             all_of,
+            array,
         }
     }
 }
@@ -8291,7 +8840,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8318,15 +8868,23 @@ pub struct AnonymousSlotExpression {
     pub any_of: Option<Vec<Box<AnonymousSlotExpression>>>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub all_of: Option<Vec<Box<AnonymousSlotExpression>>>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub array: Option<ArrayExpression>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -8334,7 +8892,10 @@ pub struct AnonymousSlotExpression {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -8345,7 +8906,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8353,7 +8915,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8361,7 +8924,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8381,7 +8945,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8393,7 +8958,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8403,7 +8969,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8411,7 +8978,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8419,7 +8987,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8427,7 +8996,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8435,7 +9005,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8443,7 +9014,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8453,7 +9025,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8471,7 +9044,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8479,7 +9053,8 @@ pub struct AnonymousSlotExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8490,7 +9065,7 @@ pub struct AnonymousSlotExpression {
 #[pymethods]
 impl AnonymousSlotExpression {
     #[new]
-    #[pyo3(signature = (range=None, range_expression=None, enum_range=None, bindings=None, required=None, recommended=None, multivalued=None, inlined=None, inlined_as_list=None, minimum_value=None, maximum_value=None, pattern=None, structured_pattern=None, unit=None, implicit_prefix=None, value_presence=None, equals_string=None, equals_string_in=None, equals_number=None, equals_expression=None, exact_cardinality=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members=None, none_of=None, exactly_one_of=None, any_of=None, all_of=None, extensions=None, annotations=None, description=None, alt_descriptions=None, title=None, deprecated=None, todos=None, notes=None, comments=None, examples=None, in_subset=None, from_schema=None, imported_from=None, source=None, in_language=None, see_also=None, deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, aliases=None, structured_aliases=None, mappings=None, exact_mappings=None, close_mappings=None, related_mappings=None, narrow_mappings=None, broad_mappings=None, created_by=None, contributors=None, created_on=None, last_updated_on=None, modified_by=None, status=None, rank=None, categories=None, keywords=None))]
+    #[pyo3(signature = (range=None, range_expression=None, enum_range=None, bindings=None, required=None, recommended=None, multivalued=None, inlined=None, inlined_as_list=None, minimum_value=None, maximum_value=None, pattern=None, structured_pattern=None, unit=None, implicit_prefix=None, value_presence=None, equals_string=None, equals_string_in=None, equals_number=None, equals_expression=None, exact_cardinality=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members=None, none_of=None, exactly_one_of=None, any_of=None, all_of=None, array=None, extensions=None, annotations=None, description=None, alt_descriptions=None, title=None, deprecated=None, todos=None, notes=None, comments=None, examples=None, in_subset=None, from_schema=None, imported_from=None, source=None, in_language=None, see_also=None, deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, aliases=None, structured_aliases=None, mappings=None, exact_mappings=None, close_mappings=None, related_mappings=None, narrow_mappings=None, broad_mappings=None, created_by=None, contributors=None, created_on=None, last_updated_on=None, modified_by=None, status=None, rank=None, categories=None, keywords=None))]
     pub fn new(
         range: Option<String>,
         range_expression: Option<serde_utils::PyValue<Box<AnonymousClassExpression>>>,
@@ -8521,6 +9096,7 @@ impl AnonymousSlotExpression {
         exactly_one_of: Option<serde_utils::PyValue<Vec<Box<AnonymousSlotExpression>>>>,
         any_of: Option<serde_utils::PyValue<Vec<Box<AnonymousSlotExpression>>>>,
         all_of: Option<serde_utils::PyValue<Vec<Box<AnonymousSlotExpression>>>>,
+        array: Option<serde_utils::PyValue<ArrayExpression>>,
         extensions: Option<serde_utils::PyValue<HashMap<String, ExtensionOrSubtype>>>,
         annotations: Option<serde_utils::PyValue<HashMap<String, Annotation>>>,
         description: Option<String>,
@@ -8570,6 +9146,7 @@ impl AnonymousSlotExpression {
         let exactly_one_of = exactly_one_of.map(|v| v.into_inner());
         let any_of = any_of.map(|v| v.into_inner());
         let all_of = all_of.map(|v| v.into_inner());
+        let array = array.map(|v| v.into_inner());
         let extensions = extensions.map(|v| v.into_inner());
         let annotations = annotations.map(|v| v.into_inner());
         let alt_descriptions = alt_descriptions.map(|v| v.into_inner());
@@ -8605,6 +9182,7 @@ impl AnonymousSlotExpression {
             exactly_one_of,
             any_of,
             all_of,
+            array,
             extensions,
             annotations,
             description,
@@ -8681,9 +9259,6 @@ pub struct SlotDefinition {
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(feature = "serde", serde(default))]
     pub slot_uri: Option<uriorcurie>,
-    #[merge(strategy = overwrite_except_none)]
-    #[cfg_attr(feature = "serde", serde(default))]
-    pub array: Option<ArrayExpression>,
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(feature = "serde", serde(default))]
     pub inherited: Option<bool>,
@@ -8786,7 +9361,10 @@ pub struct SlotDefinition {
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub type_mappings: Option<HashMap<String, TypeMapping>>,
@@ -8845,7 +9423,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8885,10 +9464,12 @@ pub struct SlotDefinition {
     pub all_of: Option<Vec<Box<AnonymousSlotExpression>>>,
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(feature = "serde", serde(default))]
+    pub array: Option<ArrayExpression>,
+    #[merge(strategy = overwrite_except_none)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub is_a: Option<String>,
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "serde", serde(alias = "abstract"))]
     pub abstract_: Option<bool>,
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8903,7 +9484,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8917,7 +9499,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8931,7 +9514,10 @@ pub struct SlotDefinition {
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub local_names: Option<HashMap<String, LocalName>>,
@@ -8942,7 +9528,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8951,7 +9538,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8959,14 +9547,20 @@ pub struct SlotDefinition {
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -8976,7 +9570,10 @@ pub struct SlotDefinition {
     #[merge(strategy = overwrite_except_none)]
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -8990,7 +9587,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -8999,7 +9597,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9008,7 +9607,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9035,7 +9635,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9050,7 +9651,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9062,7 +9664,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9071,7 +9674,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9080,7 +9684,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9089,7 +9694,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9098,7 +9704,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9107,7 +9714,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9119,7 +9727,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9143,7 +9752,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9152,7 +9762,8 @@ pub struct SlotDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9163,13 +9774,12 @@ pub struct SlotDefinition {
 #[pymethods]
 impl SlotDefinition {
     #[new]
-    #[pyo3(signature = (name, singular_name=None, domain=None, slot_uri=None, array=None, inherited=None, readonly=None, ifabsent=None, list_elements_unique=None, list_elements_ordered=None, shared=None, key=None, identifier=None, designates_type=None, alias=None, owner=None, domain_of=None, subproperty_of=None, symmetric=None, reflexive=None, locally_reflexive=None, irreflexive=None, asymmetric=None, transitive=None, inverse=None, is_class_field=None, transitive_form_of=None, reflexive_transitive_form_of=None, role=None, is_usage_slot=None, usage_slot_name=None, relational_role=None, slot_group=None, is_grouping_slot=None, path_rule=None, disjoint_with=None, children_are_mutually_disjoint=None, union_of=None, type_mappings=None, range=None, range_expression=None, enum_range=None, bindings=None, required=None, recommended=None, multivalued=None, inlined=None, inlined_as_list=None, minimum_value=None, maximum_value=None, pattern=None, structured_pattern=None, unit=None, implicit_prefix=None, value_presence=None, equals_string=None, equals_string_in=None, equals_number=None, equals_expression=None, exact_cardinality=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members=None, none_of=None, exactly_one_of=None, any_of=None, all_of=None, is_a=None, abstract_=None, mixin=None, mixins=None, apply_to=None, values_from=None, string_serialization=None, id_prefixes=None, id_prefixes_are_closed=None, definition_uri=None, local_names=None, conforms_to=None, implements=None, instantiates=None, extensions=None, annotations=None, description=None, alt_descriptions=None, title=None, deprecated=None, todos=None, notes=None, comments=None, examples=None, in_subset=None, from_schema=None, imported_from=None, source=None, in_language=None, see_also=None, deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, aliases=None, structured_aliases=None, mappings=None, exact_mappings=None, close_mappings=None, related_mappings=None, narrow_mappings=None, broad_mappings=None, created_by=None, contributors=None, created_on=None, last_updated_on=None, modified_by=None, status=None, rank=None, categories=None, keywords=None))]
+    #[pyo3(signature = (name, singular_name=None, domain=None, slot_uri=None, inherited=None, readonly=None, ifabsent=None, list_elements_unique=None, list_elements_ordered=None, shared=None, key=None, identifier=None, designates_type=None, alias=None, owner=None, domain_of=None, subproperty_of=None, symmetric=None, reflexive=None, locally_reflexive=None, irreflexive=None, asymmetric=None, transitive=None, inverse=None, is_class_field=None, transitive_form_of=None, reflexive_transitive_form_of=None, role=None, is_usage_slot=None, usage_slot_name=None, relational_role=None, slot_group=None, is_grouping_slot=None, path_rule=None, disjoint_with=None, children_are_mutually_disjoint=None, union_of=None, type_mappings=None, range=None, range_expression=None, enum_range=None, bindings=None, required=None, recommended=None, multivalued=None, inlined=None, inlined_as_list=None, minimum_value=None, maximum_value=None, pattern=None, structured_pattern=None, unit=None, implicit_prefix=None, value_presence=None, equals_string=None, equals_string_in=None, equals_number=None, equals_expression=None, exact_cardinality=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members=None, none_of=None, exactly_one_of=None, any_of=None, all_of=None, array=None, is_a=None, abstract_=None, mixin=None, mixins=None, apply_to=None, values_from=None, string_serialization=None, id_prefixes=None, id_prefixes_are_closed=None, definition_uri=None, local_names=None, conforms_to=None, implements=None, instantiates=None, extensions=None, annotations=None, description=None, alt_descriptions=None, title=None, deprecated=None, todos=None, notes=None, comments=None, examples=None, in_subset=None, from_schema=None, imported_from=None, source=None, in_language=None, see_also=None, deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, aliases=None, structured_aliases=None, mappings=None, exact_mappings=None, close_mappings=None, related_mappings=None, narrow_mappings=None, broad_mappings=None, created_by=None, contributors=None, created_on=None, last_updated_on=None, modified_by=None, status=None, rank=None, categories=None, keywords=None))]
     pub fn new(
         name: String,
         singular_name: Option<String>,
         domain: Option<String>,
         slot_uri: Option<uriorcurie>,
-        array: Option<serde_utils::PyValue<ArrayExpression>>,
         inherited: Option<bool>,
         readonly: Option<String>,
         ifabsent: Option<String>,
@@ -9233,6 +9843,7 @@ impl SlotDefinition {
         exactly_one_of: Option<serde_utils::PyValue<Vec<Box<AnonymousSlotExpression>>>>,
         any_of: Option<serde_utils::PyValue<Vec<Box<AnonymousSlotExpression>>>>,
         all_of: Option<serde_utils::PyValue<Vec<Box<AnonymousSlotExpression>>>>,
+        array: Option<serde_utils::PyValue<ArrayExpression>>,
         is_a: Option<String>,
         abstract_: Option<bool>,
         mixin: Option<bool>,
@@ -9283,7 +9894,6 @@ impl SlotDefinition {
         categories: Option<Vec<uriorcurie>>,
         keywords: Option<Vec<String>>,
     ) -> Self {
-        let array = array.map(|v| v.into_inner());
         let path_rule = path_rule.map(|v| v.into_inner());
         let type_mappings = type_mappings.map(|v| v.into_inner());
         let range_expression = range_expression.map(|v| v.into_inner());
@@ -9299,6 +9909,7 @@ impl SlotDefinition {
         let exactly_one_of = exactly_one_of.map(|v| v.into_inner());
         let any_of = any_of.map(|v| v.into_inner());
         let all_of = all_of.map(|v| v.into_inner());
+        let array = array.map(|v| v.into_inner());
         let local_names = local_names.map(|v| v.into_inner());
         let extensions = extensions.map(|v| v.into_inner());
         let annotations = annotations.map(|v| v.into_inner());
@@ -9310,7 +9921,6 @@ impl SlotDefinition {
             singular_name,
             domain,
             slot_uri,
-            array,
             inherited,
             readonly,
             ifabsent,
@@ -9374,6 +9984,7 @@ impl SlotDefinition {
             exactly_one_of,
             any_of,
             all_of,
+            array,
             is_a,
             abstract_,
             mixin,
@@ -9458,7 +10069,7 @@ impl SlotDefinition {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for SlotDefinition {
     type Key = String;
-    type Value = String;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -9470,7 +10081,15 @@ impl serde_utils::InlinedPair for SlotDefinition {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("name".into()));
+        if !already_keyed {
+            map.insert(Value::String("name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -9478,14 +10097,29 @@ impl serde_utils::InlinedPair for SlotDefinition {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("name".into()), Value::String(k));
-        map.insert(Value::String("singular_name".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("name".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -9505,7 +10139,10 @@ pub struct ClassExpression {
     pub all_of: Option<Vec<AnonymousClassExpression>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub slot_conditions: Option<HashMap<String, SlotDefinition>>,
@@ -9656,19 +10293,28 @@ pub struct AnonymousClassExpression {
     pub all_of: Option<Vec<Box<AnonymousClassExpression>>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub slot_conditions: Option<HashMap<String, Box<SlotDefinition>>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -9676,7 +10322,10 @@ pub struct AnonymousClassExpression {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -9687,7 +10336,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9695,7 +10345,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9703,7 +10354,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9723,7 +10375,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9735,7 +10388,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9745,7 +10399,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9753,7 +10408,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9761,7 +10417,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9769,7 +10426,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9777,7 +10435,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9785,7 +10444,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9795,7 +10455,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9813,7 +10474,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9821,7 +10483,8 @@ pub struct AnonymousClassExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -9963,13 +10626,19 @@ pub struct ClassDefinition {
     pub slots: Option<Vec<String>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub slot_usage: Option<HashMap<String, Box<SlotDefinition>>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub attributes: Option<HashMap<String, Box<SlotDefinition>>>,
@@ -9985,7 +10654,10 @@ pub struct ClassDefinition {
     pub tree_root: Option<bool>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub unique_keys: Option<HashMap<String, Box<UniqueKey>>>,
@@ -10002,6 +10674,10 @@ pub struct ClassDefinition {
     #[cfg_attr(feature = "serde", serde(default))]
     pub children_are_mutually_disjoint: Option<bool>,
     #[cfg_attr(feature = "serde", serde(default))]
+    pub extra_slots: Option<Box<ExtraSlotsExpression>>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub alias: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
     pub any_of: Option<Vec<Box<AnonymousClassExpression>>>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub exactly_one_of: Option<Vec<Box<AnonymousClassExpression>>>,
@@ -10011,14 +10687,16 @@ pub struct ClassDefinition {
     pub all_of: Option<Vec<Box<AnonymousClassExpression>>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub slot_conditions: Option<HashMap<String, Box<SlotDefinition>>>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub is_a: Option<String>,
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "serde", serde(alias = "abstract"))]
     pub abstract_: Option<bool>,
     #[cfg_attr(feature = "serde", serde(default))]
     pub mixin: Option<bool>,
@@ -10029,7 +10707,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10040,7 +10719,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10051,7 +10731,10 @@ pub struct ClassDefinition {
     pub definition_uri: Option<uriorcurie>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub local_names: Option<HashMap<String, LocalName>>,
@@ -10060,7 +10743,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10068,20 +10752,27 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub instantiates: Option<Vec<uriorcurie>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -10089,7 +10780,10 @@ pub struct ClassDefinition {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -10100,7 +10794,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10108,7 +10803,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10116,7 +10812,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10136,7 +10833,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10148,7 +10846,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10158,7 +10857,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10166,7 +10866,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10174,7 +10875,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10182,7 +10884,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10190,7 +10893,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10198,7 +10902,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10208,7 +10913,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10226,7 +10932,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10234,7 +10941,8 @@ pub struct ClassDefinition {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10245,7 +10953,7 @@ pub struct ClassDefinition {
 #[pymethods]
 impl ClassDefinition {
     #[new]
-    #[pyo3(signature = (name, slots=None, slot_usage=None, attributes=None, class_uri=None, subclass_of=None, union_of=None, defining_slots=None, tree_root=None, unique_keys=None, rules=None, classification_rules=None, slot_names_unique=None, represents_relationship=None, disjoint_with=None, children_are_mutually_disjoint=None, any_of=None, exactly_one_of=None, none_of=None, all_of=None, slot_conditions=None, is_a=None, abstract_=None, mixin=None, mixins=None, apply_to=None, values_from=None, string_serialization=None, id_prefixes=None, id_prefixes_are_closed=None, definition_uri=None, local_names=None, conforms_to=None, implements=None, instantiates=None, extensions=None, annotations=None, description=None, alt_descriptions=None, title=None, deprecated=None, todos=None, notes=None, comments=None, examples=None, in_subset=None, from_schema=None, imported_from=None, source=None, in_language=None, see_also=None, deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, aliases=None, structured_aliases=None, mappings=None, exact_mappings=None, close_mappings=None, related_mappings=None, narrow_mappings=None, broad_mappings=None, created_by=None, contributors=None, created_on=None, last_updated_on=None, modified_by=None, status=None, rank=None, categories=None, keywords=None))]
+    #[pyo3(signature = (name, slots=None, slot_usage=None, attributes=None, class_uri=None, subclass_of=None, union_of=None, defining_slots=None, tree_root=None, unique_keys=None, rules=None, classification_rules=None, slot_names_unique=None, represents_relationship=None, disjoint_with=None, children_are_mutually_disjoint=None, extra_slots=None, alias=None, any_of=None, exactly_one_of=None, none_of=None, all_of=None, slot_conditions=None, is_a=None, abstract_=None, mixin=None, mixins=None, apply_to=None, values_from=None, string_serialization=None, id_prefixes=None, id_prefixes_are_closed=None, definition_uri=None, local_names=None, conforms_to=None, implements=None, instantiates=None, extensions=None, annotations=None, description=None, alt_descriptions=None, title=None, deprecated=None, todos=None, notes=None, comments=None, examples=None, in_subset=None, from_schema=None, imported_from=None, source=None, in_language=None, see_also=None, deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, aliases=None, structured_aliases=None, mappings=None, exact_mappings=None, close_mappings=None, related_mappings=None, narrow_mappings=None, broad_mappings=None, created_by=None, contributors=None, created_on=None, last_updated_on=None, modified_by=None, status=None, rank=None, categories=None, keywords=None))]
     pub fn new(
         name: String,
         slots: Option<Vec<String>>,
@@ -10263,6 +10971,8 @@ impl ClassDefinition {
         represents_relationship: Option<bool>,
         disjoint_with: Option<Vec<String>>,
         children_are_mutually_disjoint: Option<bool>,
+        extra_slots: Option<serde_utils::PyValue<Box<ExtraSlotsExpression>>>,
+        alias: Option<String>,
         any_of: Option<serde_utils::PyValue<Vec<Box<AnonymousClassExpression>>>>,
         exactly_one_of: Option<serde_utils::PyValue<Vec<Box<AnonymousClassExpression>>>>,
         none_of: Option<serde_utils::PyValue<Vec<Box<AnonymousClassExpression>>>>,
@@ -10323,6 +11033,7 @@ impl ClassDefinition {
         let unique_keys = unique_keys.map(|v| v.into_inner());
         let rules = rules.map(|v| v.into_inner());
         let classification_rules = classification_rules.map(|v| v.into_inner());
+        let extra_slots = extra_slots.map(|v| v.into_inner());
         let any_of = any_of.map(|v| v.into_inner());
         let exactly_one_of = exactly_one_of.map(|v| v.into_inner());
         let none_of = none_of.map(|v| v.into_inner());
@@ -10351,6 +11062,8 @@ impl ClassDefinition {
             represents_relationship,
             disjoint_with,
             children_are_mutually_disjoint,
+            extra_slots,
+            alias,
             any_of,
             exactly_one_of,
             none_of,
@@ -10434,7 +11147,7 @@ impl<'py> FromPyObject<'py> for Box<ClassDefinition> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for ClassDefinition {
     type Key = String;
-    type Value = uriorcurie;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -10446,7 +11159,15 @@ impl serde_utils::InlinedPair for ClassDefinition {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("name".into()));
+        if !already_keyed {
+            map.insert(Value::String("name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -10454,14 +11175,29 @@ impl serde_utils::InlinedPair for ClassDefinition {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("name".into()), Value::String(k));
-        map.insert(Value::String("class_uri".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("name".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -10557,13 +11293,19 @@ pub struct ClassRule {
     pub deactivated: Option<bool>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -10571,7 +11313,10 @@ pub struct ClassRule {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -10582,7 +11327,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10590,7 +11336,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10598,7 +11345,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10618,7 +11366,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10630,7 +11379,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10640,7 +11390,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10648,7 +11399,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10656,7 +11408,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10664,7 +11417,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10672,7 +11426,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10680,7 +11435,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10690,7 +11446,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10706,7 +11463,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10714,7 +11472,8 @@ pub struct ClassRule {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10935,13 +11694,19 @@ pub struct ArrayExpression {
     pub dimensions: Option<Vec<DimensionExpression>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -10949,7 +11714,10 @@ pub struct ArrayExpression {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -10960,7 +11728,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10968,7 +11737,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10976,7 +11746,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -10996,7 +11767,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11008,7 +11780,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11018,7 +11791,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11026,7 +11800,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11034,7 +11809,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11042,7 +11818,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11050,7 +11827,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11058,7 +11836,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11068,7 +11847,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11086,7 +11866,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11094,7 +11875,8 @@ pub struct ArrayExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11234,13 +12016,19 @@ pub struct DimensionExpression {
     pub exact_cardinality: Option<isize>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -11248,7 +12036,10 @@ pub struct DimensionExpression {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -11259,7 +12050,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11267,7 +12059,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11275,7 +12068,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11295,7 +12089,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11307,7 +12102,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11317,7 +12113,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11325,7 +12122,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11333,7 +12131,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11341,7 +12140,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11349,7 +12149,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11357,7 +12158,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11367,7 +12169,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11385,7 +12188,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11393,7 +12197,8 @@ pub struct DimensionExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11530,13 +12335,19 @@ pub struct PatternExpression {
     pub partial_match: Option<bool>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -11544,7 +12355,10 @@ pub struct PatternExpression {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -11555,7 +12369,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11563,7 +12378,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11571,7 +12387,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11591,7 +12408,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11603,7 +12421,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11613,7 +12432,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11621,7 +12441,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11629,7 +12450,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11637,7 +12459,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11645,7 +12468,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11653,7 +12477,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11663,7 +12488,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11681,7 +12507,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11689,7 +12516,8 @@ pub struct PatternExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11821,19 +12649,28 @@ pub struct ImportExpression {
     pub import_as: Option<ncname>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub import_map: Option<HashMap<String, Setting>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -11841,7 +12678,10 @@ pub struct ImportExpression {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -11852,7 +12692,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11860,7 +12701,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11868,7 +12710,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11888,7 +12731,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11900,7 +12744,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11910,7 +12755,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11918,7 +12764,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11926,7 +12773,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11934,7 +12782,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11942,7 +12791,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11950,7 +12800,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11960,7 +12811,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11978,7 +12830,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -11986,7 +12839,8 @@ pub struct ImportExpression {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12168,7 +13022,15 @@ impl serde_utils::InlinedPair for Setting {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("setting_key".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("setting_key".into()));
+        if !already_keyed {
+            map.insert(Value::String("setting_key".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -12178,12 +13040,32 @@ impl serde_utils::InlinedPair for Setting {
 
     fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("setting_key".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("setting_key".into()), key_value);
         map.insert(Value::String("setting_value".into()), v);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        Some(&self.setting_value)
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("setting_key".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -12247,7 +13129,15 @@ impl serde_utils::InlinedPair for Prefix {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("prefix_prefix".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("prefix_prefix".into()));
+        if !already_keyed {
+            map.insert(Value::String("prefix_prefix".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -12257,12 +13147,32 @@ impl serde_utils::InlinedPair for Prefix {
 
     fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("prefix_prefix".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("prefix_prefix".into()), key_value);
         map.insert(Value::String("prefix_reference".into()), v);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        Some(&self.prefix_reference)
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("prefix_prefix".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -12326,7 +13236,15 @@ impl serde_utils::InlinedPair for LocalName {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("local_name_source".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("local_name_source".into()));
+        if !already_keyed {
+            map.insert(Value::String("local_name_source".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -12336,12 +13254,32 @@ impl serde_utils::InlinedPair for LocalName {
 
     fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("local_name_source".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("local_name_source".into()), key_value);
         map.insert(Value::String("local_name_value".into()), v);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        Some(&self.local_name_value)
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("local_name_source".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -12463,10 +13401,16 @@ impl serde_utils::InlinedPair for AltDescription {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(
-            Value::String("alt_description_source".into()),
-            Value::String(k),
-        );
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("alt_description_source".into()))
+            || map.contains_key(&Value::String("source".into()));
+        if !already_keyed {
+            map.insert(Value::String("alt_description_source".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -12476,15 +13420,32 @@ impl serde_utils::InlinedPair for AltDescription {
 
     fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(
-            Value::String("alt_description_source".into()),
-            Value::String(k),
-        );
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("alt_description_source".into()), key_value);
         map.insert(Value::String("alt_description_text".into()), v);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        Some(&self.alt_description_text)
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("alt_description_source".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -12504,7 +13465,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12512,7 +13474,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12523,19 +13486,28 @@ pub struct PermissibleValue {
     pub mixins: Option<Vec<String>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -12546,7 +13518,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12554,7 +13527,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12562,7 +13536,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12582,7 +13557,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12594,7 +13570,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12604,7 +13581,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12612,7 +13590,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12620,7 +13599,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12628,7 +13608,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12636,7 +13617,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12644,7 +13626,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12654,7 +13637,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12672,7 +13656,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12680,7 +13665,8 @@ pub struct PermissibleValue {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12814,7 +13800,7 @@ impl<'py> FromPyObject<'py> for Box<PermissibleValue> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for PermissibleValue {
     type Key = String;
-    type Value = String;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -12826,7 +13812,15 @@ impl serde_utils::InlinedPair for PermissibleValue {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("text".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("text".into()));
+        if !already_keyed {
+            map.insert(Value::String("text".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -12834,14 +13828,29 @@ impl serde_utils::InlinedPair for PermissibleValue {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("text".into()), Value::String(k));
-        map.insert(Value::String("description".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("text".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("text".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -12858,13 +13867,19 @@ pub struct UniqueKey {
     pub consider_nulls_inequal: Option<bool>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -12872,7 +13887,10 @@ pub struct UniqueKey {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -12883,7 +13901,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12891,7 +13910,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12899,7 +13919,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12919,7 +13940,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12931,7 +13953,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12941,7 +13964,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12949,7 +13973,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12957,7 +13982,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12965,7 +13991,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12973,7 +14000,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12981,7 +14009,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -12991,7 +14020,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13009,7 +14039,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13017,7 +14048,8 @@ pub struct UniqueKey {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13142,7 +14174,7 @@ impl<'py> FromPyObject<'py> for Box<UniqueKey> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for UniqueKey {
     type Key = String;
-    type Value = bool;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -13154,7 +14186,15 @@ impl serde_utils::InlinedPair for UniqueKey {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("unique_key_name".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("unique_key_name".into()));
+        if !already_keyed {
+            map.insert(Value::String("unique_key_name".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -13162,14 +14202,29 @@ impl serde_utils::InlinedPair for UniqueKey {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("unique_key_name".into()), Value::String(k));
-        map.insert(Value::String("consider_nulls_inequal".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("unique_key_name".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
+        }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("unique_key_name".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
         }
     }
 }
@@ -13188,13 +14243,19 @@ pub struct TypeMapping {
     pub string_serialization: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub extensions: Option<HashMap<String, ExtensionOrSubtype>>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub annotations: Option<HashMap<String, Annotation>>,
@@ -13202,7 +14263,10 @@ pub struct TypeMapping {
     pub description: Option<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional")
+        serde(
+            deserialize_with = "serde_utils::deserialize_inlined_dict_map_optional",
+            serialize_with = "serde_utils::serialize_inlined_dict_map_optional"
+        )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
     pub alt_descriptions: Option<HashMap<String, AltDescription>>,
@@ -13213,7 +14277,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13221,7 +14286,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13229,7 +14295,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13249,7 +14316,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13261,7 +14329,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13271,7 +14340,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13279,7 +14349,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13287,7 +14358,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13295,7 +14367,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13303,7 +14376,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13311,7 +14385,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13321,7 +14396,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13339,7 +14415,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13347,7 +14424,8 @@ pub struct TypeMapping {
     #[cfg_attr(
         feature = "serde",
         serde(
-            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional"
+            deserialize_with = "serde_utils::deserialize_primitive_list_or_single_value_optional",
+            serialize_with = "serde_utils::serialize_primitive_list_or_single_value_optional"
         )
     )]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -13472,7 +14550,7 @@ impl<'py> FromPyObject<'py> for Box<TypeMapping> {
 #[cfg(feature = "serde")]
 impl serde_utils::InlinedPair for TypeMapping {
     type Key = String;
-    type Value = TypeDefinition;
+    type Value = Value;
     type Error = String;
 
     fn extract_key(&self) -> &Self::Key {
@@ -13484,7 +14562,16 @@ impl serde_utils::InlinedPair for TypeMapping {
             Value::Map(m) => m,
             _ => return Err("ClassDefinition must be a mapping".into()),
         };
-        map.insert(Value::String("framework_key".into()), Value::String(k));
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        // Only inject the inferred key if the inner map does not already carry it
+        // under its canonical name or any accepted alias. Injecting unconditionally
+        // would produce a duplicate field once serde resolves aliases.
+        let already_keyed = map.contains_key(&Value::String("framework_key".into()))
+            || map.contains_key(&Value::String("framework".into()));
+        if !already_keyed {
+            map.insert(Value::String("framework_key".into()), key_value);
+        }
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
@@ -13492,15 +14579,80 @@ impl serde_utils::InlinedPair for TypeMapping {
         }
     }
 
-    fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error> {
+    fn from_pair_simple(k: Self::Key, _v: Value) -> Result<Self, Self::Error> {
         let mut map: BTreeMap<Value, Value> = BTreeMap::new();
-        map.insert(Value::String("framework_key".into()), Value::String(k));
-        map.insert(Value::String("mapped_type".into()), v);
+        let key_value = serde_value::to_value(k.clone())
+            .map_err(|e| format!("unable to serialize key: {}", e))?;
+        map.insert(Value::String("framework_key".into()), key_value);
         let de = Value::Map(map).into_deserializer();
         match serde_path_to_error::deserialize(de) {
             Ok(ok) => Ok(ok),
             Err(e) => Err(format!("at `{}`: {}", e.path(), e.inner())),
         }
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        let value = match serde_value::to_value(self) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        match value {
+            Value::Map(mut map) => {
+                map.remove(&Value::String("framework_key".into()));
+                Some(Value::Map(map))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "stubgen", gen_stub_pyclass)]
+#[cfg_attr(feature = "pyo3", pyclass(subclass, get_all, set_all))]
+pub struct ExtraSlotsExpression {
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub allowed: Option<bool>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub range_expression: Option<Box<AnonymousSlotExpression>>,
+}
+#[cfg(feature = "pyo3")]
+#[cfg_attr(feature = "stubgen", gen_stub_pymethods)]
+#[pymethods]
+impl ExtraSlotsExpression {
+    #[new]
+    #[pyo3(signature = (allowed=None, range_expression=None))]
+    pub fn new(
+        allowed: Option<bool>,
+        range_expression: Option<serde_utils::PyValue<Box<AnonymousSlotExpression>>>,
+    ) -> Self {
+        let range_expression = range_expression.map(|v| v.into_inner());
+        ExtraSlotsExpression {
+            allowed,
+            range_expression,
+        }
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> IntoPyObject<'py> for Box<ExtraSlotsExpression> {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py).map(move |x| x.into_any())
+    }
+}
+
+#[cfg(feature = "pyo3")]
+impl<'py> FromPyObject<'py> for Box<ExtraSlotsExpression> {
+    fn extract_bound(ob: &pyo3::Bound<'py, pyo3::types::PyAny>) -> pyo3::PyResult<Self> {
+        if let Ok(val) = ob.extract::<ExtraSlotsExpression>() {
+            return Ok(Box::new(val));
+        }
+        Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "invalid ExtraSlotsExpression",
+        ))
     }
 }
 

--- a/src/metamodel/src/lib.rs
+++ b/src/metamodel/src/lib.rs
@@ -1926,12 +1926,21 @@ impl<'py> FromPyObject<'py> for Anything {
                 return Ok(Value::Unit);
             }
 
-            // Try simple primitives first
-            if let Ok(s) = o.extract::<&str>() {
-                return Ok(Value::String(s.to_string()));
-            }
+            // Try simple primitives first.
+            // Order matters: Python's `bool` is a subclass of `int`, so `bool`
+            // must be tried before `i64`. Likewise, `i64` before `f64` so we
+            // don't widen integers to floats.
             if let Ok(b) = o.extract::<bool>() {
                 return Ok(Value::Bool(b));
+            }
+            if let Ok(i) = o.extract::<i64>() {
+                return Ok(Value::I64(i));
+            }
+            if let Ok(f) = o.extract::<f64>() {
+                return Ok(Value::F64(f));
+            }
+            if let Ok(s) = o.extract::<&str>() {
+                return Ok(Value::String(s.to_string()));
             }
 
             // Sequences (list/tuple)
@@ -1983,7 +1992,7 @@ impl<'py> IntoPyObject<'py> for Anything {
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        use pyo3::types::{PyAny, PyDict, PyList, PyString};
+        use pyo3::types::{PyAny, PyBytes, PyDict, PyList, PyString};
         use serde_value::Value;
 
         fn value_to_py<'py>(py: Python<'py>, v: &Value) -> pyo3::PyResult<Bound<'py, PyAny>> {
@@ -1991,6 +2000,23 @@ impl<'py> IntoPyObject<'py> for Anything {
                 Value::Unit => Ok(py.None().into_bound(py)),
                 Value::Bool(b) => Ok(pyo3::types::PyBool::new(py, *b).to_owned().into_any()),
                 Value::String(s) => Ok(PyString::new(py, s).into_any()),
+                Value::U8(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::U16(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::U32(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::U64(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::I8(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::I16(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::I32(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::I64(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::F32(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::F64(n) => Ok(n.into_pyobject(py)?.into_any()),
+                Value::Char(c) => Ok(PyString::new(py, &c.to_string()).into_any()),
+                Value::Bytes(b) => Ok(PyBytes::new(py, b).into_any()),
+                Value::Option(opt) => match opt {
+                    Some(inner) => value_to_py(py, inner),
+                    None => Ok(py.None().into_bound(py)),
+                },
+                Value::Newtype(inner) => value_to_py(py, inner),
                 Value::Seq(seq) => {
                     let list = PyList::empty(py);
                     for item in seq.iter() {
@@ -2007,14 +2033,6 @@ impl<'py> IntoPyObject<'py> for Anything {
                         dict.set_item(pk, pv)?;
                     }
                     Ok(dict.into_any())
-                }
-                // Best-effort for other serde_value variants
-                // (numbers, bytes, chars, etc.)
-                other => {
-                    // Try common cases without bringing extra deps
-                    // Numbers are converted via string if not covered above
-                    let s = format!("{:?}", other);
-                    Ok(PyString::new(py, &s).into_any())
                 }
             }
         }

--- a/src/metamodel/src/poly.rs
+++ b/src/metamodel/src/poly.rs
@@ -6451,6 +6451,7 @@ impl Expression for crate::StructuredAlias {}
 impl Expression for crate::AnonymousExpression {}
 impl Expression for crate::PathExpression {}
 impl Expression for crate::SlotExpression {}
+impl Expression for crate::ExtraSlotsExpression {}
 impl Expression for crate::AnonymousSlotExpression {}
 impl Expression for crate::SlotDefinition {}
 impl Expression for crate::AnonymousClassExpression {}
@@ -7274,6 +7275,10 @@ pub trait SlotExpression: Expression {
     ) -> Option<impl poly_containers::SeqRef<'a, crate::AnonymousSlotExpression>>;
     // fn all_of_mut(&mut self) -> &mut Option<impl poly_containers::SeqRef<'a, crate::AnonymousSlotExpression>>;
     // fn set_all_of<E>(&mut self, value: Option<&Vec<E>>) where E: Into<AnonymousSlotExpression>;
+
+    fn array<'a>(&'a self) -> Option<&'a crate::ArrayExpression>;
+    // fn array_mut(&mut self) -> &mut Option<&'a crate::ArrayExpression>;
+    // fn set_array<E>(&mut self, value: Option<E>) where E: Into<ArrayExpression>;
 }
 
 impl SlotExpression for crate::SlotExpression {
@@ -7371,6 +7376,9 @@ impl SlotExpression for crate::SlotExpression {
         &'a self,
     ) -> Option<impl poly_containers::SeqRef<'a, crate::AnonymousSlotExpression>> {
         return self.all_of.as_ref();
+    }
+    fn array<'a>(&'a self) -> Option<&'a crate::ArrayExpression> {
+        return self.array.as_ref();
     }
 }
 impl SlotExpression for crate::AnonymousSlotExpression {
@@ -7481,6 +7489,9 @@ impl SlotExpression for crate::AnonymousSlotExpression {
             .as_ref()
             .map(|x| poly_containers::ListView::new(x));
     }
+    fn array<'a>(&'a self) -> Option<&'a crate::ArrayExpression> {
+        return self.array.as_ref();
+    }
 }
 impl SlotExpression for crate::SlotDefinition {
     fn range<'a>(&'a self) -> Option<&'a str> {
@@ -7589,6 +7600,9 @@ impl SlotExpression for crate::SlotDefinition {
             .all_of
             .as_ref()
             .map(|x| poly_containers::ListView::new(x));
+    }
+    fn array<'a>(&'a self) -> Option<&'a crate::ArrayExpression> {
+        return self.array.as_ref();
     }
 }
 
@@ -7791,6 +7805,12 @@ impl SlotExpression for crate::SlotExpressionOrSubtype {
             SlotExpressionOrSubtype::SlotDefinition(val) => val.all_of().map(|x| x.to_any()),
         }
     }
+    fn array<'a>(&'a self) -> Option<&'a crate::ArrayExpression> {
+        match self {
+            SlotExpressionOrSubtype::AnonymousSlotExpression(val) => val.array(),
+            SlotExpressionOrSubtype::SlotDefinition(val) => val.array(),
+        }
+    }
 }
 
 pub trait AnonymousSlotExpression: AnonymousExpression + SlotExpression {}
@@ -7809,10 +7829,6 @@ pub trait SlotDefinition: Definition + SlotExpression {
     fn slot_uri<'a>(&'a self) -> Option<&'a crate::uriorcurie>;
     // fn slot_uri_mut(&mut self) -> &mut Option<&'a crate::uriorcurie>;
     // fn set_slot_uri(&mut self, value: Option<&'a uriorcurie>);
-
-    fn array<'a>(&'a self) -> Option<&'a crate::ArrayExpression>;
-    // fn array_mut(&mut self) -> &mut Option<&'a crate::ArrayExpression>;
-    // fn set_array<E>(&mut self, value: Option<E>) where E: Into<ArrayExpression>;
 
     fn inherited(&self) -> Option<bool>;
     // fn inherited_mut(&mut self) -> &mut Option<bool>;
@@ -7962,9 +7978,6 @@ impl SlotDefinition for crate::SlotDefinition {
     }
     fn slot_uri<'a>(&'a self) -> Option<&'a crate::uriorcurie> {
         return self.slot_uri.as_ref();
-    }
-    fn array<'a>(&'a self) -> Option<&'a crate::ArrayExpression> {
-        return self.array.as_ref();
     }
     fn inherited(&self) -> Option<bool> {
         return self.inherited;
@@ -8353,6 +8366,14 @@ pub trait ClassDefinition: Definition + ClassExpression {
     fn children_are_mutually_disjoint(&self) -> Option<bool>;
     // fn children_are_mutually_disjoint_mut(&mut self) -> &mut Option<bool>;
     // fn set_children_are_mutually_disjoint(&mut self, value: Option<bool>);
+
+    fn extra_slots<'a>(&'a self) -> Option<&'a crate::ExtraSlotsExpression>;
+    // fn extra_slots_mut(&mut self) -> &mut Option<&'a crate::ExtraSlotsExpression>;
+    // fn set_extra_slots<E>(&mut self, value: Option<E>) where E: Into<ExtraSlotsExpression>;
+
+    fn alias<'a>(&'a self) -> Option<&'a str>;
+    // fn alias_mut(&mut self) -> &mut Option<&'a str>;
+    // fn set_alias(&mut self, value: Option<&'a str>);
 }
 
 impl ClassDefinition for crate::ClassDefinition {
@@ -8414,6 +8435,12 @@ impl ClassDefinition for crate::ClassDefinition {
     }
     fn children_are_mutually_disjoint(&self) -> Option<bool> {
         return self.children_are_mutually_disjoint;
+    }
+    fn extra_slots<'a>(&'a self) -> Option<&'a crate::ExtraSlotsExpression> {
+        return self.extra_slots.as_deref();
+    }
+    fn alias<'a>(&'a self) -> Option<&'a str> {
+        return self.alias.as_deref();
     }
 }
 
@@ -8805,5 +8832,24 @@ impl TypeMapping for crate::TypeMapping {
     }
     fn string_serialization<'a>(&'a self) -> Option<&'a str> {
         return self.string_serialization.as_deref();
+    }
+}
+
+pub trait ExtraSlotsExpression: Expression {
+    fn allowed(&self) -> Option<bool>;
+    // fn allowed_mut(&mut self) -> &mut Option<bool>;
+    // fn set_allowed(&mut self, value: Option<bool>);
+
+    fn range_expression<'a>(&'a self) -> Option<&'a crate::AnonymousSlotExpression>;
+    // fn range_expression_mut(&mut self) -> &mut Option<&'a crate::AnonymousSlotExpression>;
+    // fn set_range_expression<E>(&mut self, value: Option<E>) where E: Into<AnonymousSlotExpression>;
+}
+
+impl ExtraSlotsExpression for crate::ExtraSlotsExpression {
+    fn allowed(&self) -> Option<bool> {
+        return self.allowed;
+    }
+    fn range_expression<'a>(&'a self) -> Option<&'a crate::AnonymousSlotExpression> {
+        return self.range_expression.as_deref();
     }
 }

--- a/src/metamodel/src/serde_utils.rs
+++ b/src/metamodel/src/serde_utils.rs
@@ -7,10 +7,10 @@ use serde::de::Error;
 #[cfg(feature = "serde")]
 use serde::{
     de::{DeserializeOwned, IntoDeserializer},
-    Deserialize, Deserializer,
+    Deserialize, Deserializer, Serialize, Serializer,
 };
 #[cfg(feature = "serde")]
-use serde_value::{Value, ValueDeserializer};
+use serde_value::{to_value, Value, ValueDeserializer};
 #[cfg(feature = "serde")]
 use std::collections::{BTreeMap, HashMap};
 
@@ -23,6 +23,14 @@ pub trait InlinedPair: Sized {
     fn from_pair_mapping(k: Self::Key, v: Value) -> Result<Self, Self::Error>;
     fn from_pair_simple(k: Self::Key, v: Value) -> Result<Self, Self::Error>;
     fn extract_key(&self) -> &Self::Key;
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        None
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        None
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -47,6 +55,14 @@ where
     #[inline]
     fn extract_key(&self) -> &Self::Key {
         T::extract_key(self)
+    }
+
+    fn simple_value(&self) -> Option<&Self::Value> {
+        self.as_ref().simple_value()
+    }
+
+    fn compact_value(&self) -> Option<Value> {
+        self.as_ref().compact_value()
     }
 }
 
@@ -272,6 +288,139 @@ fn py_any_to_value(bound: &Bound<'_, PyAny>) -> PyResult<Value> {
     Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
         "unsupported value type for conversion",
     ))
+}
+
+#[cfg(feature = "serde")]
+#[allow(dead_code)]
+pub fn serialize_inlined_dict_map<S, T>(
+    value: &HashMap<T::Key, T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: InlinedPair + Serialize,
+    T::Key: Serialize + Clone + Ord,
+    T::Value: Serialize,
+{
+    let mut ordered: BTreeMap<T::Key, &T> = BTreeMap::new();
+    for (k, v) in value.iter() {
+        ordered.insert(k.clone(), v);
+    }
+
+    let mut as_values: BTreeMap<T::Key, Value> = BTreeMap::new();
+    for (k, v) in ordered.iter() {
+        if let Some(simple) = v.simple_value() {
+            let val = to_value(simple).map_err(|e| <S::Error as serde::ser::Error>::custom(e))?;
+            as_values.insert((*k).clone(), val);
+            continue;
+        }
+        if let Some(compact) = v.compact_value() {
+            as_values.insert((*k).clone(), compact);
+            continue;
+        }
+        let val = to_value(*v).map_err(|e| <S::Error as serde::ser::Error>::custom(e))?;
+        as_values.insert((*k).clone(), val);
+    }
+    as_values.serialize(serializer)
+}
+
+#[cfg(feature = "serde")]
+#[allow(dead_code)]
+pub fn serialize_inlined_dict_map_optional<S, T>(
+    value: &Option<HashMap<T::Key, T>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: InlinedPair + Serialize,
+    T::Key: Serialize + Clone + Ord,
+    T::Value: Serialize,
+{
+    match value {
+        Some(map) => serialize_inlined_dict_map(map, serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+#[cfg(feature = "serde")]
+#[allow(dead_code)]
+pub fn serialize_inlined_dict_list<S, T>(value: &Vec<T>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: InlinedPair + Serialize,
+    T::Key: Serialize + Clone + Ord,
+    T::Value: Serialize,
+{
+    let mut ordered: BTreeMap<T::Key, &T> = BTreeMap::new();
+    for item in value.iter() {
+        ordered.insert(item.extract_key().clone(), item);
+    }
+
+    let mut as_values: BTreeMap<T::Key, Value> = BTreeMap::new();
+    for (k, v) in ordered.iter() {
+        if let Some(simple) = v.simple_value() {
+            let val = to_value(simple).map_err(|e| <S::Error as serde::ser::Error>::custom(e))?;
+            as_values.insert((*k).clone(), val);
+            continue;
+        }
+        if let Some(compact) = v.compact_value() {
+            as_values.insert((*k).clone(), compact);
+            continue;
+        }
+        let val = to_value(*v).map_err(|e| <S::Error as serde::ser::Error>::custom(e))?;
+        as_values.insert((*k).clone(), val);
+    }
+    as_values.serialize(serializer)
+}
+
+#[cfg(feature = "serde")]
+#[allow(dead_code)]
+pub fn serialize_inlined_dict_list_optional<S, T>(
+    value: &Option<Vec<T>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: InlinedPair + Serialize,
+    T::Key: Serialize + Clone + Ord,
+    T::Value: Serialize,
+{
+    match value {
+        Some(items) => serialize_inlined_dict_list(items, serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+#[cfg(feature = "serde")]
+#[allow(dead_code)]
+pub fn serialize_primitive_list_or_single_value<S, T>(
+    value: &Vec<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    match value.as_slice() {
+        [single] => single.serialize(serializer),
+        _ => value.serialize(serializer),
+    }
+}
+
+#[cfg(feature = "serde")]
+#[allow(dead_code)]
+pub fn serialize_primitive_list_or_single_value_optional<S, T>(
+    value: &Option<Vec<T>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    match value {
+        Some(v) => serialize_primitive_list_or_single_value(v, serializer),
+        None => serializer.serialize_none(),
+    }
 }
 
 #[cfg(all(feature = "serde", feature = "pyo3"))]

--- a/src/metamodel/src/stub_utils.rs
+++ b/src/metamodel/src/stub_utils.rs
@@ -1,0 +1,72 @@
+use std::io::{Error, ErrorKind};
+use std::path::{Component, PathBuf};
+
+/// Convert a stub module name into a relative filesystem path.
+///
+/// The generator currently expects module names that mirror Python package
+/// semantics (``foo.bar``) with optional hyphens. Hyphens are replaced with
+/// underscores and dots map to directory separators. The helper rejects
+/// absolute paths, traversal markers, or characters that cannot appear in
+/// stub files so we never escape the designated stub root.
+pub fn normalize_stub_module(name: &str) -> std::io::Result<PathBuf> {
+    if name.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "module name may not be empty",
+        ));
+    }
+
+    let normalized = name.replace('-', "_");
+    let path_str = normalized.replace('.', "/");
+    let path = PathBuf::from(&path_str);
+
+    if path.is_absolute() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("absolute module path `{name}` not allowed"),
+        ));
+    }
+
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let segment = part.to_string_lossy();
+                if segment.is_empty() {
+                    return Err(Error::new(
+                        ErrorKind::InvalidInput,
+                        format!("module name `{name}` contains an empty segment"),
+                    ));
+                }
+                if segment == "." || segment == ".." {
+                    return Err(Error::new(
+                        ErrorKind::InvalidInput,
+                        format!("module name `{name}` contains disallowed segment `{segment}`"),
+                    ));
+                }
+                if segment
+                    .chars()
+                    .any(|ch| matches!(ch, '*' | '?' | '<' | '>' | '|' | ':' | '\\' | '/'))
+                {
+                    return Err(Error::new(
+                        ErrorKind::InvalidInput,
+                        format!("module name `{name}` contains invalid characters in `{segment}`"),
+                    ));
+                }
+            }
+            Component::CurDir | Component::ParentDir => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("module name `{name}` attempts directory traversal"),
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("module name `{name}` resolves outside stub root"),
+                ));
+            }
+        }
+    }
+
+    Ok(path)
+}

--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -210,6 +210,65 @@ fn to_curie_identifier(candidate: &str, conv: &Converter) -> Option<Identifier> 
     }
 }
 
+/// LinkML's `camelcase` from `linkml_runtime.utils.formatutils`:
+/// strip, drop commas, split on runs of underscores or whitespace,
+/// capitalise each piece, concatenate.
+/// Mirrors `SchemaView.get_uri` default for `ClassDefinition`.
+fn linkml_camelcase(name: &str) -> String {
+    let cleaned = name.trim().replace(',', "");
+    let mut out = String::with_capacity(cleaned.len());
+    for word in cleaned.split(|c: char| c == '_' || c.is_whitespace()) {
+        if word.is_empty() {
+            continue;
+        }
+        let mut chars = word.chars();
+        if let Some(first) = chars.next() {
+            for u in first.to_uppercase() {
+                out.push(u);
+            }
+            out.push_str(chars.as_str());
+        }
+    }
+    out
+}
+
+/// LinkML's `underscore` from `linkml_runtime.utils.formatutils`:
+/// collapse whitespace runs into `_` and turn `-` into `_`.
+/// Mirrors `SchemaView.get_uri` default for `SlotDefinition` / `TypeDefinition`.
+fn linkml_underscore(name: &str) -> String {
+    let cleaned = name.trim().replace(',', "").replace('-', "_");
+    let mut out = String::with_capacity(cleaned.len());
+    let mut in_ws = false;
+    for c in cleaned.chars() {
+        if c.is_whitespace() {
+            if !in_ws {
+                out.push('_');
+                in_ws = true;
+            }
+        } else {
+            out.push(c);
+            in_ws = false;
+        }
+    }
+    out
+}
+
+/// Default CURIE for a class without an explicit `class_uri`, per LinkML spec.
+fn default_class_curie(default_prefix: &str, class_name: &str) -> String {
+    format!("{}:{}", default_prefix, linkml_camelcase(class_name))
+}
+
+/// Default CURIE for a slot without an explicit `slot_uri`, per LinkML spec.
+fn default_slot_curie(default_prefix: &str, slot_name: &str) -> String {
+    format!("{}:{}", default_prefix, linkml_underscore(slot_name))
+}
+
+/// Default CURIE for an enum without an explicit `enum_uri`, per LinkML spec.
+/// Enum names are not transformed.
+fn default_enum_curie(default_prefix: &str, enum_name: &str) -> String {
+    format!("{}:{}", default_prefix, enum_name)
+}
+
 fn compute_class_canonical_ids(
     schema: &SchemaDefinition,
     class_name: &str,
@@ -220,7 +279,7 @@ fn compute_class_canonical_ids(
     let default_curie = if class_name.contains(':') && class_def.class_uri.is_none() {
         class_name.to_string()
     } else {
-        format!("{}:{}", default_prefix, class_name)
+        default_class_curie(default_prefix, class_name)
     };
     let fallback = fallback_uri(schema, class_name);
     let canonical_source = class_def
@@ -245,7 +304,7 @@ fn compute_slot_canonical_ids_from_parts(
     let default_curie = if slot_name.contains(':') && explicit_uri.is_none() {
         slot_name.to_string()
     } else {
-        format!("{}:{}", default_prefix, slot_name)
+        default_slot_curie(default_prefix, slot_name)
     };
     let fallback = fallback_uri(schema, slot_name);
     let canonical_source = explicit_uri.unwrap_or(default_curie.as_str());
@@ -267,7 +326,7 @@ fn compute_enum_canonical_ids(
     let default_curie = if enum_name.contains(':') && enum_def.enum_uri.is_none() {
         enum_name.to_string()
     } else {
-        format!("{}:{}", default_prefix, enum_name)
+        default_enum_curie(default_prefix, enum_name)
     };
     let fallback = fallback_uri(schema, enum_name);
     let canonical_source = enum_def
@@ -827,11 +886,19 @@ impl SchemaView {
                 let default_id = if class_name.contains(':') && class_def.class_uri.is_none() {
                     Identifier::new(class_name)
                 } else {
-                    Identifier::new(&format!("{}:{}", default_prefix, class_name))
+                    Identifier::new(&default_class_curie(default_prefix, class_name))
                 };
                 let default_uri = default_id.to_uri(conv).map(|u| u.0).unwrap_or_else(|_| {
                     format!("{}/{}", schema.id.trim_end_matches('/'), class_name)
                 });
+                // Also remember the literal-name URI (`linkml:class_definition`) so
+                // CURIE-form lookups that quote the source-level class name keep
+                // working alongside the linkml-spec default (`linkml:ClassDefinition`).
+                let literal_curie = format!("{}:{}", default_prefix, class_name);
+                let literal_uri = Identifier::new(&literal_curie)
+                    .to_uri(conv)
+                    .map(|u| u.0)
+                    .unwrap_or_else(|_| fallback_uri(schema, class_name));
                 let canonical_ids =
                     compute_class_canonical_ids(schema, class_name, class_def, conv);
                 {
@@ -841,23 +908,23 @@ impl SchemaView {
                         .entry(class_name.clone())
                         .or_insert_with(|| (schema_uri.to_string(), class_name.clone()));
 
+                    let mut insert_uri = |uri: String| {
+                        index
+                            .class_uri_index
+                            .entry(uri)
+                            .or_insert_with(|| (schema_uri.to_string(), class_name.clone()));
+                    };
                     if let Some(curi) = &class_def.class_uri {
                         let explicit_uri = Identifier::new(curi).to_uri(conv)?.0;
-                        index
-                            .class_uri_index
-                            .entry(explicit_uri.clone())
-                            .or_insert_with(|| (schema_uri.to_string(), class_name.clone()));
+                        insert_uri(explicit_uri.clone());
                         if explicit_uri != default_uri {
-                            index
-                                .class_uri_index
-                                .entry(default_uri.clone())
-                                .or_insert_with(|| (schema_uri.to_string(), class_name.clone()));
+                            insert_uri(default_uri.clone());
                         }
                     } else {
-                        index
-                            .class_uri_index
-                            .entry(default_uri.clone())
-                            .or_insert_with(|| (schema_uri.to_string(), class_name.clone()));
+                        insert_uri(default_uri.clone());
+                    }
+                    if literal_uri != default_uri {
+                        insert_uri(literal_uri);
                     }
 
                     index
@@ -894,14 +961,25 @@ impl SchemaView {
                 let default_id = if slot_name.contains(':') && slot_def.slot_uri.is_none() {
                     Identifier::new(slot_name)
                 } else {
-                    Identifier::new(&format!("{}:{}", default_prefix, slot_name))
+                    Identifier::new(&default_slot_curie(default_prefix, slot_name))
                 };
                 let default_uri = default_id.to_uri(conv).map(|u| u.0).unwrap_or_else(|_| {
                     format!("{}/{}", schema.id.trim_end_matches('/'), slot_name)
                 });
+                // Mirror class indexing: also remember the literal-name URI so
+                // CURIE-form lookups using the source slot name keep working
+                // alongside the linkml-spec underscored default.
+                let literal_curie = format!("{}:{}", default_prefix, slot_name);
+                let literal_uri = Identifier::new(&literal_curie)
+                    .to_uri(conv)
+                    .map(|u| u.0)
+                    .unwrap_or_else(|_| fallback_uri(schema, slot_name));
 
                 let mut uris = Vec::new();
                 uris.push(default_uri.clone());
+                if literal_uri != default_uri {
+                    uris.push(literal_uri);
+                }
                 if let Some(suri) = &slot_def.slot_uri {
                     let explicit_uri = Identifier::new(suri).to_uri(conv)?.0;
                     if !uris.contains(&explicit_uri) {
@@ -1013,7 +1091,7 @@ impl SchemaView {
                 let default_id = if enum_name.contains(':') && enum_def.enum_uri.is_none() {
                     Identifier::new(enum_name)
                 } else {
-                    Identifier::new(&format!("{}:{}", default_prefix, enum_name))
+                    Identifier::new(&default_enum_curie(default_prefix, enum_name))
                 };
                 let default_uri = default_id.to_uri(conv).map(|u| u.0).unwrap_or_else(|_| {
                     format!("{}/{}", schema.id.trim_end_matches('/'), enum_name)

--- a/src/schemaview/tests/data/meta.yaml
+++ b/src/schemaview/tests/data/meta.yaml
@@ -1,6 +1,7 @@
 id: https://w3id.org/linkml/meta
 title: LinkML Schema Metamodel
 name: meta
+metamodel_version: 1.11.0
 description: |-
   The metamodel for schemas defined using the Linked Data Modeling Language framework.
 
@@ -72,6 +73,7 @@ imports:
   - linkml:mappings
   - linkml:extensions
   - linkml:annotations
+#  - linkml:validation
   - linkml:units
 
 subsets:
@@ -85,7 +87,6 @@ subsets:
       inlined as attributes. There are no enums.
   BasicSubset:
     rank: 1
-    name: BasicSubset
     title: basic subset
     description: |-
       An extension of MinimalSubset that avoids advanced constructs and can be implemented by a broad variety of tools.
@@ -97,7 +98,6 @@ subsets:
       process
   SpecificationSubset:
     rank: 2
-    name: SpecificationSubset
     title: specification subset
     description: |-
       A subset that includes all the metamodel elements that form part of the normative LinkML specification.
@@ -105,7 +105,6 @@ subsets:
       The complete LinkML specification can be found at [linkml:specification](https://w3id.org/linkml/specification)
   RelationalModelProfile:
     rank: 3
-    name: RelationalModelProfile
     title: relational model profile
     description: |-
       A profile that includes all the metamodel elements whose semantics can be expressed using the classic Relational Model.
@@ -116,14 +115,12 @@ subsets:
       concrete classes or otherwise transformed.
   ObjectOrientedProfile:
     rank: 4
-    name: ObjectOrientedProfile
     title: object oriented profile
     description: |-
       A profile that includes all the metamodel elements whose semantics can be expressed using a minimal
       implementation of the object oriented metamodel as employed by languages such as Java and Python, or
       in modeling frameworks like UML
   OwlProfile:
-    name: OwlProfile
     title: owl profile
     description: |-
       A profile that includes all the metamodel elements whose semantics can be expressed in OWL
@@ -196,7 +193,7 @@ slots:
     description: >-
       An element in another schema which this element instantiates.
     multivalued: true
-      
+
   categories:
     range: uriorcurie
     singular_name: category
@@ -281,7 +278,7 @@ slots:
       A list of structured_alias objects, used to provide aliases in conjunction with additional metadata.
     see_also:
       - linkml:aliases
-      
+
   aliases:
     aliases:
       - synonyms
@@ -1036,7 +1033,7 @@ slots:
     description: the refinement of a slot in the context of the containing class definition.
     comments:
       - >-
-        Many slots may be re-used across different classes, but the meaning of the slot may be refined by context.
+        Many slots may be reused across different classes, but the meaning of the slot may be refined by context.
         For example, a generic association model may use slots subject/predicate/object with generic semantics and
         minimal constraints. When this is subclasses, e.g. to disease-phenotype associations then slot usage may
         specify both local naming (e.g. subject=disease) and local constraints
@@ -1355,7 +1352,72 @@ slots:
     range: boolean
     description: if true then induced/mangled slot names are not created for class_usage and attributes
     status: testing
-    
+
+  extra_slots:
+    description: |
+      How a class instance handles extra data not specified in the class definition.
+      Note that this does *not* define the constraints that are placed on additional slots defined by inheriting classes.
+
+      Possible values:
+      - `allowed: true` - allow all additional data
+      - `allowed: false` (or `allowed:` or `allowed: null` while `range_expression` is `null`) -
+        forbid all additional data (default)
+      - `range_expression: ...`  - allow additional data if it matches the slot expression (see examples)
+    domain: class_definition
+    range: extra_slots_expression
+    in_subset:
+      - SpecificationSubset
+      - BasicSubset
+    examples:
+      - object:
+          allowed: true
+        description: Allow all additional data
+      - object:
+          allowed: false
+        description: Forbid any additional data
+      - object:
+          range_expression:
+            range: string
+        description: Allow additional data that are strings
+      - object:
+          range_expression:
+            range: AClassDefinition
+        description: Allow additional data if they are instances of the class definition "AClassDefinition"
+      - object:
+          range_expression:
+            any_of:
+              - range: string
+              - range: integer
+        description: allow additional data if they are either strings or integers
+      - object:
+          range_expression:
+            range: integer
+            multivalued: true
+            maximum_cardinality: 5
+        description: |
+          Allow additional data if they are lists of integers of at most length 5.
+          Note that this does *not* mean that a maximum of 5 extra slots are allowed.
+      - object:
+          range_expression:
+            range: integer
+            required: true
+        description: |
+          Allow additional data if they are integers.
+          `required` is meaningless in this context and ignored, since by definition all "extra" slots are optional.
+      - object:
+          allowed: false
+          range_expression:
+            range: string
+        description: |
+          A semantically *invalid* use of `extra_slots`, as extra slots will be forbidden and the
+          `anonymous_slot_expression` will be ignored.
+
+  allowed:
+    description: Whether or not something is allowed. Usage defined by context.
+    range: boolean
+    in_subset:
+      - SpecificationSubset
+      - BasicSubset
 
   # -----------------------------------
   # Slot definition slots
@@ -1386,6 +1448,7 @@ slots:
     inherited: true
     comments:
       - range is underspecified, as not all elements can appear as the range of a slot.
+      - to use a URI or CURIE as the range, create a class with the URI or curie as the class_uri
     description: |
       defines the type of the object of the slot.  Given the following slot definition
         S1:
@@ -1414,6 +1477,7 @@ slots:
       URI of the class that provides a semantic interpretation of the slot in a linked data context. The URI may come from any namespace and may be shared between schemas.
     comments:
       - Assigning slot_uris can provide additional hooks for interoperation, indicating a common conceptual model
+      - To use a URI or CURIE as a range, create a class with the URI or CURIE as the class_uri
     in_subset:
       - SpecificationSubset
       - BasicSubset
@@ -2095,7 +2159,7 @@ slots:
       expansion.
 
       Implementations of frameworks may choose to use this property to either (a) PARSE: implement automated normalizations
-      by parsing denormalized strings into complex objects (b) GENERARE: implement automated to_string labeling of
+      by parsing denormalized strings into complex objects (b) GENERATE: implement automated to_string labeling of
       complex objects
 
       For example, a Measurement class may have 3 fields: unit, value, and string_value. The string_value slot
@@ -2149,7 +2213,7 @@ slots:
       A collection of type mappings that specify how a slot's range should be mapped or
       serialized in different frameworks
     multivalued: true
-      
+
   framework_key:
     range: string
     alias: framework
@@ -2158,7 +2222,7 @@ slots:
       The name of a format that can be used to serialize LinkML data.
       The string value should be a code from the LinkML frameworks vocabulary,
       but this is not strictly enforced
-    
+
   mapped_type:
     range: type_definition
     alias: type
@@ -2485,7 +2549,7 @@ classes:
 
   Anything:
     class_uri: linkml:Any
-  
+
   common_metadata:
     description: Generic metadata shared across definitions
     mixin: true
@@ -2760,7 +2824,7 @@ classes:
 
   match_query:
     description: >-
-      A query that is used on an enum expression to dynamically obtain a set of permissivle values via a query that 
+      A query that is used on an enum expression to dynamically obtain a set of permissible values via a query that
       matches on properties of the external concepts.
     slots:
       - identifier_pattern
@@ -2770,7 +2834,7 @@ classes:
 
   reachability_query:
     description: >-
-      A query that is used on an enum expression to dynamically obtain a set of permissible values via walking from a 
+      A query that is used on an enum expression to dynamically obtain a set of permissible values via walking from a
       set of source nodes to a set of descendants or ancestors over a set of relationship types.
     slots:
       - source_ontology
@@ -2884,6 +2948,7 @@ classes:
       - exactly_one_of
       - any_of
       - all_of
+      - array
     slot_usage:
       any_of:
         range: anonymous_slot_expression
@@ -2902,8 +2967,6 @@ classes:
   slot_definition:
     rank: 3
     description: an element that describes how instances are related to other instances
-    annotations:
-      "rust.linkml.io/generate/merge": true
     aliases:
       - slot
       - field
@@ -2921,7 +2984,6 @@ classes:
       - singular_name
       - domain
       - slot_uri
-      - array
       - inherited
       - readonly
       - ifabsent
@@ -3013,7 +3075,6 @@ classes:
       - message
       - observation
     is_a: definition
-    class_uri: linkml:ClassDefinition
     slots:
       - slots
       - slot_usage
@@ -3030,6 +3091,8 @@ classes:
       - represents_relationship
       - disjoint_with
       - children_are_mutually_disjoint
+      - extra_slots
+      - alias
     slot_usage:
       is_a:
         range: class_definition
@@ -3232,6 +3295,21 @@ classes:
       - string_serialization
     in_subset:
       - SpecificationSubset
+
+  extra_slots_expression:
+    description: |
+      An expression that defines how to handle additional data in an instance of class
+      beyond the slots/attributes defined for that class.
+      See `extra_slots` for usage examples.
+    mixins:
+      - expression
+    slots:
+      - allowed
+      - range_expression
+    slot_usage:
+      range_expression:
+        range: anonymous_slot_expression
+
 
 # ==================================
 # Enumerations                     #

--- a/src/schemaview/tests/data/meta.yaml
+++ b/src/schemaview/tests/data/meta.yaml
@@ -2967,6 +2967,9 @@ classes:
   slot_definition:
     rank: 3
     description: an element that describes how instances are related to other instances
+    annotations:
+      "rust.linkml.io/generate/merge":
+        value: true
     aliases:
       - slot
       - field

--- a/src/schemaview/tests/data/meta.yaml
+++ b/src/schemaview/tests/data/meta.yaml
@@ -3068,7 +3068,6 @@ classes:
 
   class_definition:
     rank: 2
-    class_uri: linkml:ClassDefinition
     mixins:
       - class_expression
     description: an element whose instances are complex objects that may have slot-value assignments

--- a/src/schemaview/tests/data/meta.yaml
+++ b/src/schemaview/tests/data/meta.yaml
@@ -3068,6 +3068,7 @@ classes:
 
   class_definition:
     rank: 2
+    class_uri: linkml:ClassDefinition
     mixins:
       - class_expression
     description: an element whose instances are complex objects that may have slot-value assignments

--- a/src/schemaview/tests/data/types.yaml
+++ b/src/schemaview/tests/data/types.yaml
@@ -31,7 +31,7 @@ types:
     base: str
     description: A character string
     notes: >-
-      In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.  
+      In RDF serializations, a slot with range of string is treated as a literal or type xsd:string.
       If you are authoring schemas in LinkML YAML, the type is referenced with the lower case "string".
     exact_mappings:
       - schema:Text

--- a/src/schemaview/tests/data/units.yaml
+++ b/src/schemaview/tests/data/units.yaml
@@ -36,7 +36,7 @@ slots:
   derivation:
     range: string
     description: Expression for deriving this unit from other units
-    
+
   has_quantity_kind:
     range: uriorcurie
     slot_uri: qudt:hasQuantityKind
@@ -54,20 +54,20 @@ slots:
   abbreviation:
     slot_uri: qudt:abbreviation
     description: >-
-      An abbreviation for a unit is a short ASCII string that is used in place of the full name for the unit in 
-      contexts where non-ASCII characters would be problematic, or where using the abbreviation will enhance 
-      readability. When a power of a base unit needs to be expressed, such as squares this can be done using 
+      An abbreviation for a unit is a short ASCII string that is used in place of the full name for the unit in
+      contexts where non-ASCII characters would be problematic, or where using the abbreviation will enhance
+      readability. When a power of a base unit needs to be expressed, such as squares this can be done using
       abbreviations rather than symbols (source: qudt)
 
   descriptive_name:
     slot_uri: rdfs:label
     description: the spelled out name of the unit, for example, meter
-    
+
 classes:
   UnitOfMeasure:
     class_uri: qudt:Unit
     description: >-
-      A unit of measure, or unit, is a particular quantity value that has been chosen as a scale for 
+      A unit of measure, or unit, is a particular quantity value that has been chosen as a scale for
       measuring other quantities the same kind (more generally of equivalent dimension).
     slots:
       - symbol


### PR DESCRIPTION
Refreshes the bundled linkml metamodel under
`src/schemaview/tests/data/` to the current upstream version
(`metamodel_version: 1.11.0`) and fixes a latent `schemaview` indexer
bug that the refresh exposed.

## Why

The bundled metamodel had drifted from upstream. Bringing it forward is
necessary to consume the upstream rustgen fixes in
[linkml/linkml#3541](https://github.com/linkml/linkml/pull/3541) and to
keep our `schemaview` in sync.

Doing the refresh surfaced a real bug in
`SchemaView::get_class_by_uri`: every metamodel class without an
explicit `class_uri:` was unreachable by its spec-canonical URI.

## What the commits do

1. **`refresh bundled linkml metamodel to upstream 1.11.0`** — pulls
   in the current `meta.yaml`, `types.yaml`, `units.yaml`,
   `mappings.yaml`, `extensions.yaml`, `annotations.yaml`. The last
   three were already byte-identical; the first three carry the diff.
2. **`restore local rust merge-codegen annotation on slot_definition`**
   — the project-local `rust.linkml.io/generate/merge` annotation
   driving the `Merge` derive on `SlotDefinition` isn't part of the
   upstream schema; restored after the refresh wiped it.
3. **`restore explicit class_uri on class_definition`** — short-lived
   workaround restoring the upstream override that hid the indexer
   bug; reverted in commit 6 below.
4. **`regenerate linkml_meta rust crate`** — `gen-rust` against the
   refreshed schema, with the upstream rustgen fixes from
   linkml/linkml#3541 in effect (alias-respecting inlined-dict
   deserialization + spec-correct SimpleDict shape detection).
5. **`fix(schemaview): derive default class/slot URIs per linkml spec`**
   — the actual indexer fix. `SchemaView::get_class_by_uri` now uses
   `<default_prefix>:<camelcase(name)>` for classes and
   `<default_prefix>:<underscore(name)>` for slots, mirroring linkml's
   own `SchemaView.get_uri`. Both the spec-canonical and the
   literal-name URIs are indexed so `linkml:ClassDefinition` and
   `linkml:class_definition` both resolve. Enum names are not
   transformed.
6. **`Revert "chore(metamodel): restore explicit class_uri on class_definition"`**
   — drops the workaround now that the indexer derives the right URI
   from the bare class name.

## Test plan

- [x] `cargo test --workspace` is green
- [x] `python_api::definitions_via_python` passes against an
      unmodified upstream metamodel (no `class_uri:
      linkml:ClassDefinition` override required)
- [x] The two previously-failing schemaview tests
      (`schemaview::io::tests::test_load_schema`,
      `test_resolve_schemas`) pass against the regenerated metamodel
- [x] `cargo fmt --all` clean

## Depends on

* linkml/linkml#3541 — the rustgen-side fixes that the regenerated
  `linkml_meta` crate already includes (alias preservation +
  SimpleDict shape detection). Once that lands in a linkml release,
  consumers regenerating the metamodel locally will get the same
  output.

## Note on bisectability

The PR includes a `git revert` of commit 3 (`restore explicit
class_uri on class_definition`) rather than rewriting history. The
intermediate commit is a deliberate temporary workaround so that each
of commits 1-4 stays self-consistent and bisectable; commits 5 and 6
together replace the workaround with the real fix.