### PR TITLE
refactor(classview)!: replace SchemaView::induced_slot with ClassView::slot

### DIFF
--- a/src/python/python/linkml_runtime_rust/_native.pyi
+++ b/src/python/python/linkml_runtime_rust/_native.pyi
@@ -1372,6 +1372,12 @@ class ClassView:
         Returns the effective slots for this class, including inherited slots
         from ``is_a`` parents and mixins, with ``slot_usage`` overrides applied.
         """
+    def slot(self, id:builtins.str) -> typing.Optional[SlotView]:
+        r"""
+        Returns the effective ``SlotView`` for ``id`` within this class, or
+        ``None``. ``id`` may be a slot name, CURIE, or URI; CURIEs/URIs are
+        resolved with this class's own schema converter.
+        """
     def parent_class(self) -> typing.Optional[ClassView]:
         r"""
         Returns the ``is_a`` parent class, or ``None`` for a root class.
@@ -3761,12 +3767,6 @@ class SchemaView:
         references into the referenced class; this is union- and
         subclass-fan-out-aware, so the terminal slots may live on an entirely
         different class reached through a reference.
-        """
-    def induced_slot(self, class_id:builtins.str, slot_name:builtins.str) -> typing.Optional[SlotView]:
-        r"""
-        Return the fully-merged ``SlotView`` for ``(class_id, slot_name)``,
-        walking ``is_a``/mixins and folding in ``attributes`` + ``slot_usage``.
-        Returns ``None`` when the class or slot is unknown.
         """
     def __repr__(self) -> builtins.str: ...
     def __str__(self) -> builtins.str: ...

--- a/src/python/src/lib.rs
+++ b/src/python/src/lib.rs
@@ -458,17 +458,6 @@ impl PySchemaView {
         Ok(slots.into_iter().map(PySlotView::from).collect())
     }
 
-    /// Return the fully-merged ``SlotView`` for ``(class_id, slot_name)``,
-    /// walking ``is_a``/mixins and folding in ``attributes`` + ``slot_usage``.
-    /// Returns ``None`` when the class or slot is unknown.
-    fn induced_slot(&self, class_id: &str, slot_name: &str) -> PyResult<Option<PySlotView>> {
-        let id = Identifier::new(class_id);
-        self.inner
-            .induced_slot(&id, slot_name)
-            .map(|opt| opt.map(PySlotView::from))
-            .map_err(|e| PyException::new_err(format!("{:?}", e)))
-    }
-
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!(
             "SchemaView(n_schemas={}, n_classes={}, n_slots={})",
@@ -525,6 +514,15 @@ impl PyClassView {
             .cloned()
             .map(|s| PySlotView { inner: s })
             .collect())
+    }
+
+    /// Returns the effective ``SlotView`` for ``id`` within this class, or
+    /// ``None``. ``id`` may be a slot name, CURIE, or URI; CURIEs/URIs are
+    /// resolved with this class's own schema converter.
+    fn slot(&self, id: &str) -> Option<PySlotView> {
+        self.inner
+            .slot(&Identifier::new(id))
+            .map(|s| PySlotView { inner: s })
     }
 
     /// Returns the ``is_a`` parent class, or ``None`` for a root class.

--- a/src/schemaview/src/classview.rs
+++ b/src/schemaview/src/classview.rs
@@ -10,12 +10,21 @@ use crate::slotview::SlotView;
 
 type DescendantsIndex = HashMap<(bool, bool), OnceLock<Vec<(String, String)>>>;
 
+/// Name- and URI-keyed lookup over a class's effective slots, mirroring the
+/// `class_name_index`/`class_uri_index` strategy used by `SchemaView::get_class`.
+/// Values are indices into `ClassViewData::slots`. Built lazily on first use.
+struct SlotLookup {
+    by_name: HashMap<String, usize>,
+    by_uri: HashMap<String, usize>,
+}
+
 pub struct ClassViewData {
     pub class: ClassDefinition,
     pub slots: Vec<SlotView>,
     pub schema_uri: String,
     pub sv: SchemaView,
     descendants_index: DescendantsIndex,
+    slot_lookup: OnceLock<SlotLookup>,
 }
 
 // NOTE: `class` and `slots` are cloned snapshots taken at construction time.
@@ -35,6 +44,7 @@ impl ClassViewData {
             sv: sv.clone(),
             schema_uri: schema_uri.to_string(),
             descendants_index: HashMap::new(),
+            slot_lookup: OnceLock::new(),
         }
     }
 }
@@ -172,6 +182,7 @@ impl ClassView {
                 schema_uri: schema_uri.to_owned(),
                 sv: sv.clone(),
                 descendants_index: hm,
+                slot_lookup: OnceLock::new(),
             }),
         })
     }
@@ -180,6 +191,57 @@ impl ClassView {
     /// from `is_a` parents and mixins, with `slot_usage` overrides applied.
     pub fn slots(&self) -> &[SlotView] {
         &self.data.slots
+    }
+
+    /// Returns the effective [`SlotView`] for `id` within this class, or `None`.
+    ///
+    /// `id` may be a slot name, CURIE, or URI. CURIEs and URIs are resolved with
+    /// this class's own schema converter — prefix maps can conflict across
+    /// schemas, so there is no sound "global" converter to resolve against.
+    /// Like every [`SlotView`], the result is the fully-merged slot; pairs with
+    /// [`slots`](Self::slots).
+    ///
+    /// Lookup mirrors [`SchemaView::get_class`]: an O(1) name/URI index (built
+    /// once per `ClassView`, which is itself cached) rather than a scan.
+    pub fn slot(&self, id: &Identifier) -> Option<SlotView> {
+        let lookup = self
+            .data
+            .slot_lookup
+            .get_or_init(|| self.build_slot_lookup());
+        let idx = match id {
+            Identifier::Name(name) => lookup.by_name.get(name).copied(),
+            Identifier::Curie(_) | Identifier::Uri(_) => {
+                let conv = self.data.sv.converter_for_schema(&self.data.schema_uri)?;
+                let target = id.to_uri(&conv).ok()?;
+                lookup.by_uri.get(&target.0).copied()
+            }
+        }?;
+        self.data.slots.get(idx).cloned()
+    }
+
+    fn build_slot_lookup(&self) -> SlotLookup {
+        let mut by_name = HashMap::with_capacity(self.data.slots.len());
+        let mut by_uri = HashMap::with_capacity(self.data.slots.len());
+        for (i, s) in self.data.slots.iter().enumerate() {
+            // First definition wins on collision, matching `get_class`'s
+            // `or_insert_with` indexes.
+            by_name.entry(s.name.clone()).or_insert(i);
+            // Resolve each slot's canonical URI with its *own* schema converter
+            // (slots may be inherited from a parent class in another schema).
+            let canonical = match s.canonical_uri() {
+                Identifier::Uri(u) => Some(u.0),
+                other => self
+                    .data
+                    .sv
+                    .converter_for_schema(&s.schema_uri)
+                    .and_then(|conv| other.to_uri(&conv).ok())
+                    .map(|u| u.0),
+            };
+            if let Some(uri) = canonical {
+                by_uri.entry(uri).or_insert(i);
+            }
+        }
+        SlotLookup { by_name, by_uri }
     }
 
     /// Returns the raw [`ClassDefinition`] for this class (without inheritance).

--- a/src/schemaview/src/schemaview.rs
+++ b/src/schemaview/src/schemaview.rs
@@ -1554,22 +1554,6 @@ impl SchemaView {
         Ok(self.index().slot_entries.values().cloned().collect())
     }
 
-    /// Return the fully-merged [`SlotView`] for `(class_id, slot_name)`, walking
-    /// `is_a`/mixins and folding in `attributes` + `slot_usage`. Returns `None`
-    /// when the class or slot is unknown.
-    pub fn induced_slot(
-        &self,
-        class_id: &Identifier,
-        slot_name: &str,
-    ) -> Result<Option<SlotView>, SchemaViewError> {
-        let conv = self.converter();
-        let cv = match self.get_class(class_id, &conv)? {
-            Some(cv) => cv,
-            None => return Ok(None),
-        };
-        Ok(cv.slots().iter().find(|s| s.name == slot_name).cloned())
-    }
-
     /// Looks up a top-level slot by name, CURIE, or URI.
     pub fn get_slot(
         &self,

--- a/src/schemaview/tests/slot_usage_annotation_merge.rs
+++ b/src/schemaview/tests/slot_usage_annotation_merge.rs
@@ -1,6 +1,7 @@
 use linkml_schemaview::identifier::Identifier;
 use linkml_schemaview::io::from_yaml;
 use linkml_schemaview::schemaview::SchemaView;
+use linkml_schemaview::slotview::SlotView;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -19,11 +20,17 @@ fn fixture_schema_view() -> SchemaView {
     sv
 }
 
+/// Resolve the effective `slot` of `class` through the new `ClassView::slot`
+/// API. Single-schema fixture, so the primary converter is unambiguous.
+fn merged_slot(sv: &SchemaView, class: &str, slot: &str) -> Option<SlotView> {
+    let conv = sv.converter();
+    let cv = sv.get_class(&Identifier::new(class), &conv).unwrap()?;
+    cv.slot(&Identifier::new(slot))
+}
+
 fn annotation_keys(sv: &SchemaView, class: &str) -> Vec<String> {
-    let slot = sv
-        .induced_slot(&Identifier::new(class), "hasName")
-        .unwrap()
-        .unwrap_or_else(|| panic!("hasName not found on {class}"));
+    let slot =
+        merged_slot(sv, class, "hasName").unwrap_or_else(|| panic!("hasName not found on {class}"));
     let mut keys: Vec<String> = slot
         .definition()
         .annotations
@@ -35,10 +42,8 @@ fn annotation_keys(sv: &SchemaView, class: &str) -> Vec<String> {
 }
 
 fn annotation_value(sv: &SchemaView, class: &str, key: &str) -> Option<String> {
-    let slot = sv
-        .induced_slot(&Identifier::new(class), "hasName")
-        .unwrap()
-        .unwrap_or_else(|| panic!("hasName not found on {class}"));
+    let slot =
+        merged_slot(sv, class, "hasName").unwrap_or_else(|| panic!("hasName not found on {class}"));
     let ann = slot.definition().annotations.clone()?;
     let entry = ann.get(key)?;
     if let serde_value::Value::String(s) = &entry.extension_value.0 {
@@ -132,10 +137,7 @@ fn extensions_merge_per_key_through_chain() {
     let sv = fixture_schema_view();
 
     fn extension_keys(sv: &SchemaView, class: &str) -> Vec<String> {
-        let slot = sv
-            .induced_slot(&Identifier::new(class), "hasName")
-            .unwrap()
-            .unwrap();
+        let slot = merged_slot(sv, class, "hasName").unwrap();
         let mut keys: Vec<String> = slot
             .definition()
             .extensions
@@ -162,10 +164,7 @@ fn local_names_merge_per_key_through_chain() {
     let sv = fixture_schema_view();
 
     fn local_name_map(sv: &SchemaView, class: &str) -> HashMap<String, String> {
-        let slot = sv
-            .induced_slot(&Identifier::new(class), "hasName")
-            .unwrap()
-            .unwrap();
+        let slot = merged_slot(sv, class, "hasName").unwrap();
         slot.definition()
             .local_names
             .as_ref()
@@ -197,20 +196,14 @@ fn local_names_merge_per_key_through_chain() {
 }
 
 #[test]
-fn induced_slot_returns_none_for_unknown_class_or_slot() {
+fn slot_returns_none_for_unknown_class_or_slot() {
     let sv = fixture_schema_view();
-    assert!(sv
-        .induced_slot(&Identifier::new("NoSuchClass"), "hasName")
-        .unwrap()
-        .is_none());
-    assert!(sv
-        .induced_slot(&Identifier::new("Parent"), "noSuchSlot")
-        .unwrap()
-        .is_none());
+    assert!(merged_slot(&sv, "NoSuchClass", "hasName").is_none());
+    assert!(merged_slot(&sv, "Parent", "noSuchSlot").is_none());
 }
 
 #[test]
-fn induced_slot_matches_classview_slots_lookup() {
+fn slot_matches_classview_slots_lookup() {
     let sv = fixture_schema_view();
     let conv = sv.converter();
     let cv = sv
@@ -223,12 +216,30 @@ fn induced_slot_matches_classview_slots_lookup() {
         .find(|s| s.name == "hasName")
         .cloned()
         .unwrap();
-    let from_induced = sv
-        .induced_slot(&Identifier::new("Grandchild"), "hasName")
-        .unwrap()
-        .unwrap();
+    let from_lookup = cv.slot(&Identifier::new("hasName")).unwrap();
     assert_eq!(
         from_class_slots.definition().annotations,
-        from_induced.definition().annotations,
+        from_lookup.definition().annotations,
+    );
+}
+
+#[test]
+fn slot_lookup_by_uri_matches_by_name() {
+    let sv = fixture_schema_view();
+    let conv = sv.converter();
+    let cv = sv
+        .get_class(&Identifier::new("Grandchild"), &conv)
+        .unwrap()
+        .unwrap();
+    let by_name = cv.slot(&Identifier::new("hasName")).unwrap();
+    // Resolving by the slot's own canonical URI must find the same slot.
+    let uri = by_name.canonical_uri();
+    let by_uri = cv
+        .slot(&uri)
+        .expect("lookup by canonical URI should resolve");
+    assert_eq!(by_name.name, by_uri.name);
+    assert_eq!(
+        by_name.definition().annotations,
+        by_uri.definition().annotations,
     );
 }


### PR DESCRIPTION
## What

Replaces the freshly-added `SchemaView::induced_slot(class_id, slot_name)` with **`ClassView::slot(&Identifier) -> Option<SlotView>`**.

```rust
// before
sv.induced_slot(&class_id, "hasName")?
// after
cv.slot(&Identifier::new("hasName"))   // cv = sv.get_class(&class_id, &conv)?
```

## Why

1. **Drop "induced".** linkml-python has both `get_slot` and `induced_slot` because *both return `SlotDefinition`* — same type, different content, so the name carries the disambiguation. Here the return type is `SlotView`, which is *inherently* the merged/effective thing (`.definition()` = merged, `.definitions()` = raw chain). The raw-vs-induced axis is owned by the type, not the lookup. `ClassView::slots()` already returns induced slots without saying "induced"; this just makes the single-slot accessor consistent.
2. **No global converter.** Lookup by CURIE/URI resolves with the **class's own schema converter**. A merged "global" converter is ill-defined — prefix maps can conflict across schemas, so it silently picks a winner and can misresolve a CURIE that was unambiguous in its own schema. The removed `induced_slot` used `self.converter()` (global), which had exactly this latent bug.
3. **Belongs on `ClassView`.** Pairs with `slots()`; reads as `cv.slot("…")`.

## Lookup strategy

Mirrors `SchemaView::get_class`: an **O(1)** name/URI index built lazily (`OnceLock`) per `ClassView`. `ClassView`s are cached in `clas_view_cache`, so the index is amortized — no linear scan on the hot path.

## Changes

- `ClassView::slot` + lazy per-class `SlotLookup` (name + canonical-URI → slot index).
- Removed `SchemaView::induced_slot`.
- Python: `SchemaView.induced_slot` → `ClassView.slot(id)`; stubs regenerated.
- Tests updated to the new API; added a by-URI round-trip test.

## Breaking

`SchemaView::induced_slot` is removed — use `get_class(class_id)?.slot(id)`. Introduced in #99, no released consumers.

## Verification

`fmt --check`, `clippy -D warnings`, `stub_gen --check`, and `cargo test --workspace` (71 result blocks ok, 0 failed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)