### PR TITLE
fix(runtime): coerce integer scalars to float at boxing time

### DIFF
--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -990,7 +990,7 @@ impl LinkMLInstance {
             }
             (true, other) => Ok(LinkMLInstance::Scalar {
                 node_id: new_node_id(),
-                value: other,
+                value: Self::coerce_scalar_to_range(other, Some(&sl)),
                 slot: sl.clone(),
                 class: Some(class.clone()),
                 sv: sv.clone(),
@@ -1170,6 +1170,35 @@ impl LinkMLInstance {
         })
     }
 
+    /// Canonicalise an integer JSON scalar to a float when the slot's range is
+    /// a real-valued number type (`float`/`double`/`decimal`).
+    ///
+    /// `114` and `114.0` denote the same real number, but they box to distinct
+    /// `serde_json::Number` variants and compare unequal, so a value authored
+    /// server-side (`114.0`) and the same value round-tripped through a JSON int
+    /// (`114`, e.g. via a browser that has no int/float distinction) would diff
+    /// as a spurious update. Coercing at this single boxing chokepoint makes the
+    /// representation canonical before any diff/equals/patch sees it.
+    /// See design doc `57-int-float-spurious-delta`.
+    fn coerce_scalar_to_range(value: JsonValue, slot: Option<&SlotView>) -> JsonValue {
+        let JsonValue::Number(ref n) = value else {
+            return value;
+        };
+        if n.is_f64() {
+            return value;
+        }
+        let Some(slot) = slot else {
+            return value;
+        };
+        if !slot.is_range_floating_point() {
+            return value;
+        }
+        match n.as_f64().and_then(serde_json::Number::from_f64) {
+            Some(f) => JsonValue::Number(f),
+            None => value,
+        }
+    }
+
     fn parse_scalar_value(
         value: JsonValue,
         class: ClassView,
@@ -1190,6 +1219,7 @@ impl LinkMLInstance {
                 ),
             )
         })?;
+        let value = Self::coerce_scalar_to_range(value, Some(&sl));
         run_slot_constraints(Some(&class), &sl, &value, path.clone(), validation_issues);
         if value.is_null() {
             Ok(LinkMLInstance::Null {
@@ -1433,7 +1463,7 @@ impl LinkMLInstance {
                     scalar_slot.name.clone(),
                     LinkMLInstance::Scalar {
                         node_id: new_node_id(),
-                        value: other,
+                        value: Self::coerce_scalar_to_range(other, Some(&scalar_slot)),
                         slot: scalar_slot.clone(),
                         class: Some(range_cv.clone()),
                         sv: sv.clone(),

--- a/src/runtime/src/lib.rs
+++ b/src/runtime/src/lib.rs
@@ -98,6 +98,17 @@ fn path_to_string(path: &[String]) -> String {
     }
 }
 
+/// Convert a float to `i64` only when it is exactly integral and within range,
+/// so canonicalising `114.0` to an integer never rounds or loses data. Returns
+/// `None` for fractional, infinite, NaN, or out-of-range values.
+fn f64_to_exact_i64(f: f64) -> Option<i64> {
+    if f.fract() == 0.0 && (i64::MIN as f64..=i64::MAX as f64).contains(&f) {
+        Some(f as i64)
+    } else {
+        None
+    }
+}
+
 fn alt_names(name: &str) -> Vec<String> {
     let mut v = Vec::new();
     if name.contains('_') {
@@ -1170,33 +1181,44 @@ impl LinkMLInstance {
         })
     }
 
-    /// Canonicalise an integer JSON scalar to a float when the slot's range is
-    /// a real-valued number type (`float`/`double`/`decimal`).
+    /// Canonicalise a numeric JSON scalar to the representation its declared
+    /// range expects, so the same value boxes identically regardless of which
+    /// path produced it.
     ///
-    /// `114` and `114.0` denote the same real number, but they box to distinct
+    /// `114` and `114.0` denote the same number but box to distinct
     /// `serde_json::Number` variants and compare unequal, so a value authored
-    /// server-side (`114.0`) and the same value round-tripped through a JSON int
-    /// (`114`, e.g. via a browser that has no int/float distinction) would diff
-    /// as a spurious update. Coercing at this single boxing chokepoint makes the
-    /// representation canonical before any diff/equals/patch sees it.
-    /// See design doc `57-int-float-spurious-delta`.
+    /// server-side and the same value round-tripped through a layer with no
+    /// int/float distinction (notably a browser — JavaScript collapses `114.0`
+    /// to `114`) would diff as a spurious update. Coercing at this single boxing
+    /// chokepoint makes the representation canonical before any diff/equals/patch
+    /// sees it. See design doc `57-int-float-spurious-delta`.
+    ///
+    /// Only the int/float distinction is representationally ambiguous across
+    /// JSON producers; every other scalar range has a single unambiguous JSON
+    /// form and is left untouched.
     fn coerce_scalar_to_range(value: JsonValue, slot: Option<&SlotView>) -> JsonValue {
-        let JsonValue::Number(ref n) = value else {
+        let (JsonValue::Number(n), Some(slot)) = (&value, slot) else {
             return value;
         };
-        if n.is_f64() {
-            return value;
+        if slot.is_range_floating_point() {
+            // Integer literal for a real-valued range -> float, so it compares
+            // equal to a server-authored float (114 == 114.0).
+            if !n.is_f64() {
+                if let Some(f) = n.as_f64().and_then(serde_json::Number::from_f64) {
+                    return JsonValue::Number(f);
+                }
+            }
+        } else if slot.is_range_integer() {
+            // Whole float literal for an integer range -> integer. Fractional or
+            // out-of-range values are left intact so validation can flag them
+            // rather than silently losing data.
+            if n.is_f64() {
+                if let Some(i) = n.as_f64().and_then(f64_to_exact_i64) {
+                    return JsonValue::Number(i.into());
+                }
+            }
         }
-        let Some(slot) = slot else {
-            return value;
-        };
-        if !slot.is_range_floating_point() {
-            return value;
-        }
-        match n.as_f64().and_then(serde_json::Number::from_f64) {
-            Some(f) => JsonValue::Number(f),
-            None => value,
-        }
+        value
     }
 
     fn parse_scalar_value(

--- a/src/runtime/tests/diff.rs
+++ b/src/runtime/tests/diff.rs
@@ -549,3 +549,88 @@ fn diff_and_patch_multiple_removes_from_scalar_list() {
         "patched source should equal target after multi-remove"
     );
 }
+
+/// Regression: a `float`-ranged slot whose value is supplied as a JSON integer
+/// (`114`) must box to the same representation as the equivalent float (`114.0`)
+/// so the two compare equal and produce no spurious `Update` delta.
+/// See design doc `57-int-float-spurious-delta`.
+#[test]
+fn diff_int_vs_float_no_spurious_delta_on_float_range() {
+    use linkml_runtime::LinkMLInstance;
+    let schema = from_yaml(Path::new(&info_path("personinfo.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let person = class_in_schema(&sv, &schema, "Person");
+
+    // `duration` (range: float) supplied as a bare integer — mimics a value
+    // round-tripped through a layer with no int/float distinction.
+    let as_int = load_json_instance(
+        r#"{
+            "id": "P:1",
+            "name": "Alice",
+            "has_employment_history": [
+                { "started_at_time": "2019-01-01", "duration": 114 }
+            ]
+        }"#,
+        &sv,
+        &person,
+        &conv,
+    );
+    // The same value supplied as a float — mimics a server-authored value.
+    let as_float = load_json_instance(
+        r#"{
+            "id": "P:1",
+            "name": "Alice",
+            "has_employment_history": [
+                { "started_at_time": "2019-01-01", "duration": 114.0 }
+            ]
+        }"#,
+        &sv,
+        &person,
+        &conv,
+    );
+
+    // Boxing must canonicalise the integer to a float.
+    let duration = as_int
+        .navigate_path(["has_employment_history", "0", "duration"])
+        .unwrap();
+    if let LinkMLInstance::Scalar { value, .. } = duration {
+        assert!(
+            value.is_f64(),
+            "integer supplied for a float range should box as f64, got {value:?}"
+        );
+    } else {
+        panic!("expected scalar duration");
+    }
+
+    // No spurious delta in either direction.
+    assert!(
+        diff(&as_int, &as_float, DiffOptions::new(false)).is_empty(),
+        "int vs float of the same value must not diff"
+    );
+    assert!(
+        diff(&as_float, &as_int, DiffOptions::new(false)).is_empty(),
+        "float vs int of the same value must not diff"
+    );
+
+    // A genuine numeric change must still be detected.
+    let changed = load_json_instance(
+        r#"{
+            "id": "P:1",
+            "name": "Alice",
+            "has_employment_history": [
+                { "started_at_time": "2019-01-01", "duration": 116 }
+            ]
+        }"#,
+        &sv,
+        &person,
+        &conv,
+    );
+    let deltas = diff(&as_int, &changed, DiffOptions::new(false));
+    assert!(
+        deltas.iter().any(|d| d.op == DeltaOp::Update
+            && d.path.iter().any(|seg| seg == "duration")),
+        "a real change to a float field must still diff, got: {deltas:?}"
+    );
+}

--- a/src/runtime/tests/diff.rs
+++ b/src/runtime/tests/diff.rs
@@ -629,8 +629,9 @@ fn diff_int_vs_float_no_spurious_delta_on_float_range() {
     );
     let deltas = diff(&as_int, &changed, DiffOptions::new(false));
     assert!(
-        deltas.iter().any(|d| d.op == DeltaOp::Update
-            && d.path.iter().any(|seg| seg == "duration")),
+        deltas
+            .iter()
+            .any(|d| d.op == DeltaOp::Update && d.path.iter().any(|seg| seg == "duration")),
         "a real change to a float field must still diff, got: {deltas:?}"
     );
 }

--- a/src/runtime/tests/diff.rs
+++ b/src/runtime/tests/diff.rs
@@ -634,3 +634,74 @@ fn diff_int_vs_float_no_spurious_delta_on_float_range() {
         "a real change to a float field must still diff, got: {deltas:?}"
     );
 }
+
+/// Regression (symmetric direction): an `integer`-ranged slot whose value is
+/// supplied as a whole float (`30.0`) must box to the same integer as `30`, so
+/// the two compare equal and produce no spurious `Update` delta. A fractional
+/// value (`30.5`) must NOT be coerced — it is left intact for validation.
+/// See design doc `57-int-float-spurious-delta`.
+#[test]
+fn diff_float_vs_int_no_spurious_delta_on_integer_range() {
+    use linkml_runtime::LinkMLInstance;
+    let schema = from_yaml(Path::new(&info_path("personinfo.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let person = class_in_schema(&sv, &schema, "Person");
+
+    // `age_in_years` (range: integer) supplied as a whole float.
+    let as_float = load_json_instance(
+        r#"{ "id": "P:1", "name": "Alice", "age_in_years": 30.0 }"#,
+        &sv,
+        &person,
+        &conv,
+    );
+    let as_int = load_json_instance(
+        r#"{ "id": "P:1", "name": "Alice", "age_in_years": 30 }"#,
+        &sv,
+        &person,
+        &conv,
+    );
+
+    // Boxing must canonicalise the whole float to an integer.
+    let age = as_float.navigate_path(["age_in_years"]).unwrap();
+    if let LinkMLInstance::Scalar { value, .. } = age {
+        assert!(
+            value.is_i64() || value.is_u64(),
+            "whole float supplied for an integer range should box as integer, got {value:?}"
+        );
+    } else {
+        panic!("expected scalar age_in_years");
+    }
+
+    assert!(
+        diff(&as_float, &as_int, DiffOptions::new(false)).is_empty(),
+        "whole float vs int of the same value must not diff"
+    );
+    assert!(
+        diff(&as_int, &as_float, DiffOptions::new(false)).is_empty(),
+        "int vs whole float of the same value must not diff"
+    );
+
+    // A fractional value must be left intact (not coerced), so it can be flagged
+    // by validation and still differs from the integer.
+    let fractional = load_json_instance(
+        r#"{ "id": "P:1", "name": "Alice", "age_in_years": 30.5 }"#,
+        &sv,
+        &person,
+        &conv,
+    );
+    let frac_age = fractional.navigate_path(["age_in_years"]).unwrap();
+    if let LinkMLInstance::Scalar { value, .. } = frac_age {
+        assert!(
+            value.is_f64(),
+            "a fractional value must not be coerced to integer, got {value:?}"
+        );
+    } else {
+        panic!("expected scalar age_in_years");
+    }
+    assert!(
+        !diff(&as_int, &fractional, DiffOptions::new(false)).is_empty(),
+        "30 vs 30.5 must still diff"
+    );
+}

--- a/src/schemaview/src/slotview.rs
+++ b/src/schemaview/src/slotview.rs
@@ -82,6 +82,34 @@ impl RangeInfo {
     /// Well-known XSD string IRI — plain string literals should not carry an
     /// explicit `^^xsd:string` datatype annotation since they are equivalent.
     const XSD_STRING: &'static str = "http://www.w3.org/2001/XMLSchema#string";
+    /// XSD IRIs of the real-valued (non-integer) number types. A value typed
+    /// against one of these is semantically a real number, so `114` and `114.0`
+    /// denote the same value even though their JSON representations differ.
+    const XSD_FLOAT: &'static str = "http://www.w3.org/2001/XMLSchema#float";
+    const XSD_DOUBLE: &'static str = "http://www.w3.org/2001/XMLSchema#double";
+    const XSD_DECIMAL: &'static str = "http://www.w3.org/2001/XMLSchema#decimal";
+
+    /// `true` when this range is a real-valued number type (`float`, `double`
+    /// or `decimal`), for which an integer JSON literal should be canonicalised
+    /// to a floating-point representation at boxing time.
+    ///
+    /// Prefers the resolved RDF datatype IRI (which also catches user-defined
+    /// subtypes of `float`/`double`/`decimal`), and falls back to the builtin
+    /// LinkML type names so detection still works when the `linkml:types`
+    /// schema that defines those IRIs has not been loaded.
+    pub fn is_floating_point(&self) -> bool {
+        if matches!(
+            self.rdf_datatype_iri.as_deref(),
+            Some(Self::XSD_FLOAT | Self::XSD_DOUBLE | Self::XSD_DECIMAL)
+        ) {
+            return true;
+        }
+        // Only the range itself, not a class/enum, can be a number type.
+        if self.range_class.is_some() || self.range_enum.is_some() {
+            return false;
+        }
+        matches!(self.e.range(), Some("float" | "double" | "decimal"))
+    }
 
     pub fn new(e: SlotExpressionOrSubtype, slotview: SlotView) -> Self {
         let range_class = Self::determine_range_class(&e, &slotview);
@@ -464,6 +492,16 @@ impl SlotView {
         self.get_range_info()
             .first()
             .is_none_or(|ri| ri.is_range_scalar)
+    }
+
+    /// Returns `true` when the primary range is a real-valued number type
+    /// (`float`, `double` or `decimal`). Used at boxing time to canonicalise an
+    /// integer JSON literal (`114`) to a float (`114.0`) so it compares equal to
+    /// a server-authored float regardless of which path produced the value.
+    pub fn is_range_floating_point(&self) -> bool {
+        self.get_range_info()
+            .first()
+            .is_some_and(|ri| ri.is_floating_point())
     }
 
     /// Returns the resolved container shape for this slot.

--- a/src/schemaview/src/slotview.rs
+++ b/src/schemaview/src/slotview.rs
@@ -88,6 +88,15 @@ impl RangeInfo {
     const XSD_FLOAT: &'static str = "http://www.w3.org/2001/XMLSchema#float";
     const XSD_DOUBLE: &'static str = "http://www.w3.org/2001/XMLSchema#double";
     const XSD_DECIMAL: &'static str = "http://www.w3.org/2001/XMLSchema#decimal";
+    /// XSD IRI of the integer number type.
+    const XSD_INTEGER: &'static str = "http://www.w3.org/2001/XMLSchema#integer";
+
+    /// Builtin LinkML type names for the number types, used as a fallback when
+    /// the `linkml:types` schema that defines the XSD IRIs above has not been
+    /// loaded (e.g. bare test schemas). There is no schema-free way to name a
+    /// builtin type other than by its reserved name.
+    const FLOAT_TYPE_NAMES: &'static [&'static str] = &["float", "double", "decimal"];
+    const INTEGER_TYPE_NAMES: &'static [&'static str] = &["integer"];
 
     /// `true` when this range is a real-valued number type (`float`, `double`
     /// or `decimal`), for which an integer JSON literal should be canonicalised
@@ -104,11 +113,27 @@ impl RangeInfo {
         ) {
             return true;
         }
-        // Only the range itself, not a class/enum, can be a number type.
+        self.range_name_matches(Self::FLOAT_TYPE_NAMES)
+    }
+
+    /// `true` when this range is the integer number type, for which a whole
+    /// float JSON literal (`114.0`) should be canonicalised to an integer.
+    ///
+    /// Same IRI-primary, name-fallback resolution as [`is_floating_point`](Self::is_floating_point).
+    pub fn is_integer(&self) -> bool {
+        if matches!(self.rdf_datatype_iri.as_deref(), Some(Self::XSD_INTEGER)) {
+            return true;
+        }
+        self.range_name_matches(Self::INTEGER_TYPE_NAMES)
+    }
+
+    /// Fallback range check by builtin type name. Only the range itself, never
+    /// a class or enum, can be a number type.
+    fn range_name_matches(&self, names: &[&str]) -> bool {
         if self.range_class.is_some() || self.range_enum.is_some() {
             return false;
         }
-        matches!(self.e.range(), Some("float" | "double" | "decimal"))
+        self.e.range().is_some_and(|r| names.contains(&r))
     }
 
     pub fn new(e: SlotExpressionOrSubtype, slotview: SlotView) -> Self {
@@ -502,6 +527,15 @@ impl SlotView {
         self.get_range_info()
             .first()
             .is_some_and(|ri| ri.is_floating_point())
+    }
+
+    /// Returns `true` when the primary range is the integer number type. Used at
+    /// boxing time to canonicalise a whole float JSON literal (`114.0`) to an
+    /// integer (`114`).
+    pub fn is_range_integer(&self) -> bool {
+        self.get_range_info()
+            .first()
+            .is_some_and(|ri| ri.is_integer())
     }
 
     /// Returns the resolved container shape for this slot.


### PR DESCRIPTION
Number fields declared as float/double/decimal kept their raw JSON representation when boxed by load_json, so a value authored server-side (114.0) and the same value round-tripped through a layer with no int/float distinction (114) compared unequal in diff/equals and produced a spurious update delta.

Coerce an integer JSON scalar to f64 at the single boxing chokepoint when the slot's range is a real-valued number type, so the value is canonical before any diff/equals/patch sees it. Detection prefers the resolved RDF datatype IRI (also catches subtypes of float/double/decimal) and falls back to the builtin LinkML type names.