### PR TITLE
fix(schemaview): resolve default_curi_maps and builtin linkml: import prefixes

### DIFF
--- a/src/schemaview/src/identifier.rs
+++ b/src/schemaview/src/identifier.rs
@@ -192,20 +192,177 @@ fn add_missing_prefix(prefix: &str, uri: &str, conv: &mut Converter) {
     }
 }
 
+// ── `default_curi_maps` + builtin `linkml:` import prefix resolution ──────
+//
+// `linkml_runtime.SchemaView`/`SchemaLoader` resolve prefixes from three
+// sources, in order, never letting a later source override an earlier one
+// (`Namespaces.add_prefixmap`'s `elif k not in self` rule):
+//   1. `prefixes:` declared inline on the schema (and, once loaded, on every
+//      imported schema — Python recursively loads `imports:` and merges each
+//      imported schema's own `prefixes:` in the same way).
+//   2. `default_curi_maps:` — named, well-known prefix bundles (e.g.
+//      `semweb_context`) resolved against the `prefixcommons`/`prefixmaps`
+//      registries.
+//   3. A tiny hardcoded fallback (this crate only; not present in Python).
+//
+// Previously this function implemented only (1) (for schemas already loaded
+// into the `SchemaView`) and (3). `default_curi_maps` was parsed onto
+// `SchemaDefinition` but never read here, and prefixes from **builtin**
+// `linkml:` imports (`linkml:types`, `linkml:mappings`, `linkml:extensions`,
+// `linkml:annotations`, `linkml:units` — the schemas bundled with the LinkML
+// language itself) were unreachable unless the `resolve` feature's network
+// fetch (`resolve::resolve_schemas`) had already run and added them as
+// separate schemas — which never happens automatically during
+// `SchemaView::add_schema_with_import_ref`'s own indexing step, the exact
+// point where CURIE resolution is needed and errors are raised. A schema
+// that relied on either mechanism to resolve prefixes like `schema:`/`xsd:`
+// (very common: LinkML's own metamodel does this) failed to load at all.
+//
+// `builtin_prefix_contributions` closes both gaps **synchronously, without
+// network access**, by bundling the prefix tables of the 5 known-fixed
+// builtin schemas (see `resolve::get_uri_for_id` for the same identity list,
+// used there for full-content resolution) and a small registry of named
+// curie maps. It does not attempt to resolve arbitrary/non-builtin imports
+// or curie maps — those remain unresolved exactly as before, with no
+// behaviour change for schemas that don't use these builtins.
+fn builtin_prefix_contributions(schema: &SchemaDefinition) -> Vec<(&'static str, &'static str)> {
+    let mut out = Vec::new();
+    if let Some(maps) = &schema.default_curi_maps {
+        for name in maps {
+            if let Some(entries) = named_curi_map(name) {
+                out.extend_from_slice(entries);
+            }
+        }
+    }
+    if let Some(imports) = &schema.imports {
+        for import in imports {
+            if let Some(entries) = builtin_linkml_schema_prefixes(import) {
+                out.extend_from_slice(entries);
+            }
+        }
+    }
+    out
+}
+
+/// A bundled `default_curi_maps` entry, or `None` if we don't recognise
+/// `name`. Only `semweb_context` — the map LinkML's own metamodel and
+/// mappings schemas declare, and the one most commonly seen in the wild —
+/// is bundled today. Add more `BIOCONTEXT_CONTEXTS`/`PREFIXMAPS_CONTEXTS`
+/// entries here as they come up; an unrecognised name is simply left
+/// unresolved, matching the pre-existing "unresolved is not fatal here"
+/// behaviour for anything this crate can't supply.
+fn named_curi_map(name: &str) -> Option<&'static [(&'static str, &'static str)]> {
+    match name {
+        "semweb_context" => Some(SEMWEB_CONTEXT),
+        _ => None,
+    }
+}
+
+/// The `semweb_context` prefix map, transcribed verbatim from
+/// `prefixcommons/prefixcommons-py`'s
+/// `prefixcommons/registry/semweb_context.jsonld` `@context` object — the
+/// exact source `linkml_runtime.Namespaces.add_prefixmap` reads via
+/// `curie_util.read_biocontext("semweb_context")`. Verified against a real
+/// `linkml-runtime` install to match key-for-key, value-for-value.
+const SEMWEB_CONTEXT: &[(&str, &str)] = &[
+    ("dc", "http://purl.org/dc/terms/"),
+    ("dcat", "http://www.w3.org/ns/dcat#"),
+    ("dcterms", "http://purl.org/dc/terms/"),
+    ("faldo", "http://biohackathon.org/resource/faldo#"),
+    ("foaf", "http://xmlns.com/foaf/0.1/"),
+    ("idot", "http://identifiers.org/"),
+    ("oa", "http://www.w3.org/ns/oa#"),
+    ("oboInOwl", "http://www.geneontology.org/formats/oboInOwl#"),
+    ("owl", "http://www.w3.org/2002/07/owl#"),
+    ("prov", "http://www.w3.org/ns/prov#"),
+    ("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+    ("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
+    ("void", "http://rdfs.org/ns/void#"),
+    ("xsd", "http://www.w3.org/2001/XMLSchema#"),
+];
+
+/// The prefixes declared by one of the 5 core LinkML schemas bundled with
+/// the language itself, or `None` if `import` isn't one of them. Recognises
+/// both the CURIE form (`linkml:types`) and the fully-expanded URI form
+/// (`https://w3id.org/linkml/types`), since schema authors may write
+/// either — matching by literal import identity, the same identity list
+/// `resolve::get_uri_for_id` uses for full-content network resolution, so
+/// this never duplicates or conflicts with that mechanism (which still owns
+/// resolving imported *classes/slots*; this only ever contributes prefixes).
+fn builtin_linkml_schema_prefixes(import: &str) -> Option<&'static [(&'static str, &'static str)]> {
+    match import {
+        "linkml:types" | "https://w3id.org/linkml/types" => Some(LINKML_TYPES_PREFIXES),
+        "linkml:mappings" | "https://w3id.org/linkml/mappings" => Some(LINKML_MAPPINGS_PREFIXES),
+        "linkml:extensions" | "https://w3id.org/linkml/extensions" => {
+            Some(LINKML_EXTENSIONS_PREFIXES)
+        }
+        "linkml:annotations" | "https://w3id.org/linkml/annotations" => {
+            Some(LINKML_ANNOTATIONS_PREFIXES)
+        }
+        "linkml:units" | "https://w3id.org/linkml/units" => Some(LINKML_UNITS_PREFIXES),
+        _ => None,
+    }
+}
+
+/// `prefixes:` block of `linkml_model/model/schema/types.yaml`. Importing
+/// `linkml:types` is how a schema makes `schema:`/`xsd:` resolvable without
+/// listing them inline — a very common pattern (LinkML's own metamodel uses
+/// it). Transcribed verbatim from the canonical source; each of the 5
+/// tables below is refreshed the same way.
+const LINKML_TYPES_PREFIXES: &[(&str, &str)] = &[
+    ("linkml", "https://w3id.org/linkml/"),
+    ("xsd", "http://www.w3.org/2001/XMLSchema#"),
+    ("shex", "http://www.w3.org/ns/shex#"),
+    ("schema", "http://schema.org/"),
+];
+
+/// `prefixes:` block of `linkml_model/model/schema/mappings.yaml`.
+const LINKML_MAPPINGS_PREFIXES: &[(&str, &str)] = &[
+    ("linkml", "https://w3id.org/linkml/"),
+    ("skos", "http://www.w3.org/2004/02/skos/core#"),
+    ("OIO", "http://www.geneontology.org/formats/oboInOwl#"),
+    ("IAO", "http://purl.obolibrary.org/obo/IAO_"),
+];
+
+/// `prefixes:` block of `linkml_model/model/schema/extensions.yaml`.
+const LINKML_EXTENSIONS_PREFIXES: &[(&str, &str)] = &[("linkml", "https://w3id.org/linkml/")];
+
+/// `prefixes:` block of `linkml_model/model/schema/annotations.yaml`.
+const LINKML_ANNOTATIONS_PREFIXES: &[(&str, &str)] = &[("linkml", "https://w3id.org/linkml/")];
+
+/// `prefixes:` block of `linkml_model/model/schema/units.yaml`.
+const LINKML_UNITS_PREFIXES: &[(&str, &str)] = &[
+    ("linkml", "https://w3id.org/linkml/"),
+    ("qudt", "http://qudt.org/schema/qudt/"),
+];
+
 /// Build a [`Converter`] from one or more [`SchemaDefinition`]s.
 ///
 /// All prefixes declared in the schemas are added to the converter. Duplicate
-/// prefixes are ignored.
+/// prefixes are ignored. Prefixes contributed by a schema's
+/// `default_curi_maps` or its builtin `linkml:` imports (see
+/// [`builtin_prefix_contributions`]) are then merged in without overriding
+/// anything already registered — matching `linkml_runtime`'s
+/// "explicit always wins" precedence.
 pub fn converter_from_schemas<'a, I>(schemas: I) -> Converter
 where
     I: IntoIterator<Item = &'a SchemaDefinition>,
 {
     let mut conv = Converter::default();
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
+    // Keyed by URI so that prefixes sharing a URI (e.g. `dc`/`dcterms`, both
+    // `http://purl.org/dc/terms/` in `semweb_context`) become synonyms on one
+    // `Record`, rather than separate records — `Converter::add_record`
+    // rejects a second record for a URI that is already claimed, so merging
+    // same-URI prefixes as flat, independent `add_prefix` calls would
+    // silently drop every prefix after the first for that URI.
     let mut map: HashMap<String, Record> = HashMap::new();
+    let mut known_prefixes: HashSet<String> = HashSet::new();
+    let mut builtin_contributions: Vec<(&'static str, &'static str)> = Vec::new();
     for schema in schemas {
         if let Some(prefixes) = &schema.prefixes {
             for (pfx, pref) in prefixes {
+                known_prefixes.insert(pfx.clone());
                 match map.get_mut(&pref.prefix_reference) {
                     Some(rec) => {
                         rec.prefix_synonyms.insert(pfx.clone());
@@ -215,6 +372,24 @@ where
                         map.insert(pref.prefix_reference.clone(), r);
                     }
                 }
+            }
+        }
+        builtin_contributions.extend(builtin_prefix_contributions(schema));
+    }
+    // PARITY: explicit `prefixes:` (merged above) always win over
+    // default_curi_maps / builtin-import-derived prefixes, matching
+    // `Namespaces.add_prefixmap`'s `k not in self` rule — checked per-prefix
+    // via `known_prefixes`, independent of any URI-sharing among builtins.
+    for (pfx, uri) in builtin_contributions {
+        if !known_prefixes.insert(pfx.to_string()) {
+            continue;
+        }
+        match map.get_mut(uri) {
+            Some(rec) => {
+                rec.prefix_synonyms.insert(pfx.to_string());
+            }
+            None => {
+                map.insert(uri.to_string(), Record::new(pfx, uri));
             }
         }
     }

--- a/src/schemaview/tests/default_curi_maps.rs
+++ b/src/schemaview/tests/default_curi_maps.rs
@@ -1,0 +1,187 @@
+//! Covers `default_curi_maps:` and builtin `linkml:` import prefix
+//! resolution (see `identifier::builtin_prefix_contributions`).
+//!
+//! Before this fix, a schema that relied on either mechanism to resolve a
+//! prefix like `schema:`/`owl:` — instead of declaring it inline under
+//! `prefixes:` — failed `SchemaView::add_schema` outright with
+//! `CurieError(NotFound(..))` the moment it indexed a class/slot using that
+//! prefix, since `converter_from_schemas` only ever read inline `prefixes:`
+//! plus a 3-entry hardcoded fallback (`rdfs`/`rdf`/`dcterms`).
+
+use linkml_meta::SchemaDefinition;
+use linkml_schemaview::identifier::{converter_from_schemas, Identifier};
+use linkml_schemaview::schemaview::SchemaView;
+
+fn schema_from_yaml(yaml: &str) -> SchemaDefinition {
+    serde_yml::from_str(yaml).expect("test schema should parse")
+}
+
+/// A schema whose `id`/`name` slot uses `slot_uri: schema:identifier`
+/// without declaring `schema:` inline, relying entirely on
+/// `imports: [linkml:types]` to supply it — the exact shape that used to
+/// fail `add_schema` (reproduced from a real-world fixture that hit this).
+const IMPORT_ONLY_SCHEMA: &str = r#"
+id: https://example.org/import-only
+name: import_only
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+classes:
+  Entity:
+    slots:
+      - id
+slots:
+  id:
+    identifier: true
+    slot_uri: schema:identifier
+"#;
+
+#[test]
+fn builtin_linkml_types_import_resolves_schema_prefix() {
+    let schema = schema_from_yaml(IMPORT_ONLY_SCHEMA);
+    let mut sv = SchemaView::new();
+    // This used to fail with CurieError(NotFound("schema")) — `schema:` was
+    // unreachable without the (network-only) `resolve` feature having
+    // already loaded `linkml:types` as a separate schema.
+    sv.add_schema(schema.clone())
+        .expect("add_schema should succeed once `schema:` is resolved via the builtin import");
+
+    let conv = converter_from_schemas([&schema]);
+    let uri = Identifier::new("schema:identifier")
+        .to_uri(&conv)
+        .expect("schema: should resolve via the bundled linkml:types prefixes");
+    assert_eq!(uri.0, "http://schema.org/identifier");
+}
+
+/// A schema relying on `default_curi_maps: [semweb_context]` alone (no
+/// import) to resolve `owl:`, which is not in the 3-entry hardcoded
+/// fallback (`rdfs`/`rdf`/`dcterms`).
+const CURI_MAP_ONLY_SCHEMA: &str = r#"
+id: https://example.org/curimap-only
+name: curimap_only
+prefixes:
+  linkml: https://w3id.org/linkml/
+default_curi_maps:
+  - semweb_context
+default_range: string
+classes:
+  Entity:
+    slots:
+      - same_as
+slots:
+  same_as:
+    slot_uri: owl:sameAs
+"#;
+
+#[test]
+fn default_curi_maps_resolves_semweb_context_prefix() {
+    let schema = schema_from_yaml(CURI_MAP_ONLY_SCHEMA);
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone())
+        .expect("add_schema should succeed once owl: is resolved via default_curi_maps");
+
+    let conv = converter_from_schemas([&schema]);
+    let uri = Identifier::new("owl:sameAs")
+        .to_uri(&conv)
+        .expect("owl: should resolve via the bundled semweb_context map");
+    assert_eq!(uri.0, "http://www.w3.org/2002/07/owl#sameAs");
+}
+
+/// An explicit `prefixes:` entry must win over a same-keyed prefix that
+/// would otherwise be contributed by a builtin import — mirrors
+/// `linkml_runtime.Namespaces.add_prefixmap`'s `k not in self` precedence.
+const EXPLICIT_OVERRIDE_SCHEMA: &str = r#"
+id: https://example.org/explicit-override
+name: explicit_override
+prefixes:
+  linkml: https://w3id.org/linkml/
+  schema: https://custom.example.org/schema#
+imports:
+  - linkml:types
+default_range: string
+classes:
+  Entity:
+    slots:
+      - id
+slots:
+  id:
+    identifier: true
+    slot_uri: schema:identifier
+"#;
+
+#[test]
+fn explicit_prefix_wins_over_builtin_import_contribution() {
+    let schema = schema_from_yaml(EXPLICIT_OVERRIDE_SCHEMA);
+    let conv = converter_from_schemas([&schema]);
+    let uri = Identifier::new("schema:identifier")
+        .to_uri(&conv)
+        .expect("schema: is declared explicitly, should always resolve");
+    assert_eq!(uri.0, "https://custom.example.org/schema#identifier");
+}
+
+/// The fully-expanded URI form of a builtin import (as opposed to the CURIE
+/// shorthand) must be recognised too.
+const EXPANDED_URI_IMPORT_SCHEMA: &str = r#"
+id: https://example.org/expanded-import
+name: expanded_import
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - https://w3id.org/linkml/types
+default_range: string
+classes:
+  Entity:
+    slots:
+      - id
+slots:
+  id:
+    identifier: true
+    slot_uri: schema:identifier
+"#;
+
+#[test]
+fn builtin_import_matches_expanded_uri_form() {
+    let schema = schema_from_yaml(EXPANDED_URI_IMPORT_SCHEMA);
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone())
+        .expect("add_schema should succeed with the fully-expanded import URI too");
+
+    let conv = converter_from_schemas([&schema]);
+    let uri = Identifier::new("schema:identifier").to_uri(&conv).unwrap();
+    assert_eq!(uri.0, "http://schema.org/identifier");
+}
+
+/// A schema with neither `default_curi_maps` nor a builtin import is
+/// unaffected — no behaviour change for the common case.
+const PLAIN_SCHEMA: &str = r#"
+id: https://example.org/plain
+name: plain
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://example.org/ex#
+default_range: string
+classes:
+  Entity:
+    slots:
+      - id
+slots:
+  id:
+    identifier: true
+    slot_uri: ex:id
+"#;
+
+#[test]
+fn plain_schema_without_builtins_is_unaffected() {
+    let schema = schema_from_yaml(PLAIN_SCHEMA);
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).expect("plain schema loads");
+
+    let conv = converter_from_schemas([&schema]);
+    let uri = Identifier::new("ex:id").to_uri(&conv).unwrap();
+    assert_eq!(uri.0, "https://example.org/ex#id");
+
+    // An unrelated builtin-only prefix must NOT leak in from nowhere.
+    assert!(Identifier::new("schema:identifier").to_uri(&conv).is_err());
+}


### PR DESCRIPTION
> EDIT: FYI full disclosure - this is vibe coded with Claude Sonnet 5- **I didn't mean to push yet***, but its fine
> The code looks good, I have tried to stay faithful to the upstream python (which I do know, but I am in the process of learning rust, so can't guarantee..)
> Feel free to reject/ suggest revisions / whatever


Fixes #105.

## What

`converter_from_schemas` (`identifier.rs`) previously only registered prefixes declared inline under a schema's `prefixes:`, plus a hardcoded 3-entry fallback (`rdfs`/`rdf`/`dcterms`). It never read `default_curi_maps`, and prefixes from builtin `linkml:` imports (`linkml:types`, `linkml:mappings`, `linkml:extensions`, `linkml:annotations`, `linkml:units`) were only reachable via the network-only `resolve` feature — which never runs automatically during `add_schema`'s own indexing step, the exact point where `CurieError` gets raised. A schema relying on either mechanism to resolve a prefix like `schema:`/`owl:` without declaring it inline (a common pattern — LinkML's own metamodel does this) failed `add_schema` outright.

`linkml_runtime.SchemaView`/`SchemaLoader` resolve both, with "explicit always wins" precedence (`Namespaces.add_prefixmap`'s `k not in self` rule).

## The fix

Added `builtin_prefix_contributions`, merging in — synchronously, no network access, no dependency on imports already being loaded as separate schemas:

- `default_curi_maps` entries resolved against a small bundled registry (`semweb_context` today; trivially extensible via one match arm — an unrecognised name is left unresolved exactly as before, so this is purely additive)
- prefixes of the 5 builtin `linkml:` schemas (matching both the CURIE and fully-expanded-URI import forms), transcribed verbatim from `linkml_model`'s actual schema files. Uses the same identity list `resolve::get_uri_for_id` already has for full-content network resolution — this PR only ever contributes *prefixes*, so it doesn't duplicate or conflict with that mechanism, which still owns resolving imported classes/slots.

Merge precedence matches `Namespaces.add_prefixmap` exactly: explicit `prefixes:` always win.

## A bug this surfaced along the way

Building the merged table required grouping same-URI prefixes as `Converter::Record` synonyms (the way the pre-existing explicit-prefix path already does), rather than adding each builtin prefix independently via `add_prefix`. `semweb_context` has both `dc` and `dcterms` mapping to the same URI (`http://purl.org/dc/terms/`), and `Converter::add_record` rejects a second record for an already-claimed URI — so a flat per-prefix merge silently drops the second prefix. This was caught by the existing `io::tests::test_resolve_schemas` unit test (loads the real LinkML metamodel schema), which started failing with `CurieError(NotFound("dcterms"))` during development until the merge was restructured to group by URI first.

## Tests

Added `src/schemaview/tests/default_curi_maps.rs`:
- a schema resolving `schema:` via `imports: [linkml:types]` alone (the reported bug's exact shape)
- a schema resolving `owl:` via `default_curi_maps: [semweb_context]` alone
- an explicit-prefix-wins precedence test
- an expanded-URI-form import test (`https://w3id.org/linkml/types` vs. `linkml:types`)
- a control test proving a plain schema using neither mechanism is unaffected (no behaviour change for the common case)

## Verification

- `cargo test --workspace`: all passing, 0 failures
- `cargo clippy -p schemaview --all-targets`: clean (no new warnings; pre-existing warnings are all in the generated `linkml_meta` crate, untouched by this change)
- Confirmed against a real `linkml-runtime==1.11.1` / `linkml==1.11.1` install that the bundled prefix tables match `linkml_model`'s actual schema files and `prefixcommons`' `semweb_context.jsonld` byte-for-byte